### PR TITLE
fix(reporting-rate-summary): fix get request

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "classnames": "^2.2.6",
     "connected-react-router": "^6.2.2",
     "css-loader": "0.28.7",
-    "d2": "^31.4.0",
+    "d2": "^31.5.0",
     "d2-manifest": "^1.0.0",
     "d3-color": "^1.2.0",
     "dotenv": "4.0.0",
@@ -123,7 +123,7 @@
       "name": "DHIS2"
     },
     "dhis2": {
-      "apiVersion": "31"
+      "apiVersion": "32"
     },
     "activities": {
       "dhis": {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -159,6 +159,7 @@ export const getReportingRateSummaryReport = async (
         .withTableLayout()
         .withHideEmptyRows()
         .withDisplayProperty('SHORTNAME')
+        .withIncludeNumDen(false)
 
     for (let key in orgUnitOptions) {
         if (orgUnitOptions[key]) {
@@ -166,9 +167,11 @@ export const getReportingRateSummaryReport = async (
         }
     }
 
-    const fileUrls = parseFileUrls(req, ['xls', 'csv'])
-
-    return d2.analytics.aggregate.get(req).then(data => ({ ...data, fileUrls }))
+    // Instead of calling `d2.analytics.aggregate.get(req)`, which spawn two parallel requests,
+    // we just building the .json url from the request instance and call the regular `api.get(url)`,
+    // which only spawns a single request
+    const [{ url }, ...fileUrls] = parseFileUrls(req, ['json', 'xls', 'csv'])
+    return api.get(url).then(data => ({ ...data, fileUrls }))
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3019,7 +3019,14 @@ d2@31.1.1, d2@~31.1:
     jsdoc "^3.5.5"
     whatwg-fetch "^2.0.3"
 
-d2@^31.4.0, d2@~31.4:
+d2@^31.5.0:
+  version "31.5.0"
+  resolved "https://registry.yarnpkg.com/d2/-/d2-31.5.0.tgz#e562f856e372128d2a67273adc9579b88537d6dc"
+  integrity sha512-5ohhu9YypOZCcxMGVtdzC8KUhElpQ917mVw+o53rvwzLt4SzQBFqq6iq06Oq5UCzqlif6OhO2A46DgK3ywuyyQ==
+  dependencies:
+    isomorphic-fetch "^2.2.1"
+
+d2@~31.4:
   version "31.4.0"
   resolved "https://registry.yarnpkg.com/d2/-/d2-31.4.0.tgz#761e297d0f6a5b4b1d6043de176d887ee5faa09b"
   integrity sha512-8Bw4W4XVc6jDlZ/+g2TJW6iuxcLAi8ii8Iv0tRBe1M+WjH+x6UWfQuMKxXL/hZtOaa0TNiRouyp50pVBuXawIw==
@@ -5499,7 +5506,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
-isomorphic-fetch@^2.1.1:
+isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   dependencies:


### PR DESCRIPTION
Some on context on what led to this PR:
- After upgrading the d2 package to 31.4, which was needed for bi-weekly period type support, `getReportingRateSummaryReport` kept returning empty rows.
- This turned out to be the result of a change in d2, which caused `includeNumDen=true` to be appended to the query parameters of the request url. When removing this parameter, or changing it to `includeNumDen=false`, the correct data was returned.
- There currently is a bug in d2 which makes it impossible to set `includeNumDen` to false. I have submitted a PR to fix this here https://github.com/dhis2/d2/pull/201
- However, I also noticed in the d2 docs and codebase that calling `d2.analytics.aggregate.get(req)` spawns two requests instead of one. This is for caching purposes, but I don't think very suitable for our scenario.
- And because we were already producing some URLs for the file downloads, it was very easy to just rewrite things to a `api.get` call, which only triggers one request.

So now, the big choice:

1. Keep the current solution, which is perhaps slightly hack, but very bandwidth effective.
2. Wait until https://github.com/dhis2/d2/pull/201 is accepted and merged, and then keep using `d2.analytics.aggregate.get(req)`, which is a lot less hacky to look at, but will trigger an additional request.

FYI: some info reg. the two parallel requests [can be found here](https://d2-ci.github.io/d2/module-analytics.AnalyticsEvents.html#get)