### PR TITLE
fix(html reports): full paths to jquery and dhis.utils

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -50,6 +50,11 @@ export const getD2 = () => d2
 export const getApi = () => api
 
 /**
+ * @returns {string} context path
+ */
+export const getContextPath = () => d2.system.systemInfo.contextPath
+
+/**
  * @return {Promise} Period types
  */
 export const getPeriodTypes = () =>

--- a/src/utils/dom/loadScript.js
+++ b/src/utils/dom/loadScript.js
@@ -1,8 +1,10 @@
+import { getContextPath } from '../api'
+
 export const loadScript = src => {
+    const serverUrl = getContextPath()
     const script = document.createElement('script')
     script.type = 'text/javascript'
-    script.src = src
-
+    script.src = serverUrl + src
     const scriptPromise = new Promise(resolve => {
         script.onload = resolve
     })


### PR DESCRIPTION
This fixes the `Uncaught SyntaxError: Unexpected token <` errors in `jquery.min.js:1` and `dhis2.util.js:1`. These errors actually meant that the file was not found, so we needed to fix them. We are now using an absolute path. I think it should work in production too.