### PR TITLE
fix(lists): improve behavior when deleting from lists

### DIFF
--- a/src/components/SearchablePagedList.js
+++ b/src/components/SearchablePagedList.js
@@ -36,7 +36,7 @@ const SearchablePagedList = props => {
                 onChange={props.searchInputChangeHandler}
             />
             <Table
-                rows={props.rows}
+                rows={props.isLoading ? [] : props.rows}
                 columns={props.columns}
                 contextMenuActions={props.contextMenuActions}
                 primaryAction={props.primaryAction}

--- a/src/pages/Resource.js
+++ b/src/pages/Resource.js
@@ -13,7 +13,7 @@ const createContextMenuOptions = props => ({
     [resourceActions.VIEW]: props.viewResource,
     [resourceActions.EDIT]: props.editResource,
     [resourceActions.SHARING_SETTINGS]: props.showSharingSettings,
-    [resourceActions.DELETE]: props.deleteResource,
+    [resourceActions.DELETE]: props.requestDeleteResource,
 })
 
 class Resource extends React.Component {
@@ -27,7 +27,9 @@ class Resource extends React.Component {
     }
 
     componentDidMount() {
-        this.props.loadResources()
+        if (this.props.resources.length === 0) {
+            this.props.loadResources()
+        }
     }
 
     render() {
@@ -64,7 +66,10 @@ class Resource extends React.Component {
                         selectedResource={this.props.selectedResource}
                         handleClose={this.props.closeContextMenu}
                     />
-                    <Snackbar />
+                    <Snackbar
+                        action={i18n.t('CONFIRM')}
+                        onActionClick={this.props.deleteResource}
+                    />
                 </div>
             </div>
         )
@@ -85,6 +90,7 @@ Resource.propTypes = {
     goToNextPage: PropTypes.func.isRequired,
     goToPrevPage: PropTypes.func.isRequired,
     loadResources: PropTypes.func.isRequired,
+    requestDeleteResource: PropTypes.func.isRequired,
     deleteResource: PropTypes.func.isRequired,
     setSearch: PropTypes.func.isRequired,
     addResource: PropTypes.func.isRequired,

--- a/src/pages/StandardReport.js
+++ b/src/pages/StandardReport.js
@@ -32,7 +32,9 @@ class StandardReport extends React.Component {
     }
 
     componentDidMount() {
-        this.props.loadStandardReports(true)
+        if (this.props.reports.length === 0) {
+            this.props.loadStandardReports(true)
+        }
     }
 
     render() {

--- a/src/pages/resource/connectResource.js
+++ b/src/pages/resource/connectResource.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import {
     addResource,
     closeContextMenu,
+    requestDeleteResource,
     deleteResource,
     editResource,
     goToNextPage,
@@ -27,6 +28,7 @@ const mapDispatchToProps = {
     goToNextPage,
     goToPrevPage,
     loadResources,
+    requestDeleteResource,
     deleteResource,
     setSearch: event => setSearchAndLoadResources(event.target.value),
     addResource,

--- a/src/redux/actions/__tests__/resource.test.js
+++ b/src/redux/actions/__tests__/resource.test.js
@@ -74,13 +74,19 @@ describe('Actions - resource', () => {
 
     describe('deleting resources', () => {
         const resource = { id: '1337' }
+        const store = mockStore({
+            pagination: {},
+            resource: {
+                selectedResource: resource,
+            },
+        })
 
         it('should dispatch a loading start action when deleting resources', () => {
             const expectedActions = expect.arrayContaining([
                 deleteResourceStart(),
             ])
 
-            store.dispatch(deleteResource(resource)).then(() => {
+            store.dispatch(deleteResource()).then(() => {
                 expect(store.getActions()).toEqual(expectedActions)
             })
         })
@@ -94,7 +100,7 @@ describe('Actions - resource', () => {
                 Promise.resolve()
             )
 
-            store.dispatch(deleteResource(resource)).then(() => {
+            store.dispatch(deleteResource()).then(() => {
                 expect(store.getActions()).toEqual(expectedActions)
             })
         })
@@ -108,7 +114,7 @@ describe('Actions - resource', () => {
                 Promise.reject()
             )
 
-            store.dispatch(deleteResource(resource)).then(() => {
+            store.dispatch(deleteResource()).then(() => {
                 expect(store.getActions()).toEqual(expectedActions)
             })
         })

--- a/src/redux/actions/resource.js
+++ b/src/redux/actions/resource.js
@@ -187,14 +187,15 @@ export const addResource = resource => ({
  * Used to get a confirmation from the user
  * @return {Object}
  */
+const confirmationMessage = i18n.t(
+    'Do you really want to delete this resource?'
+)
 export const requestDeleteResource = resource => dispatch => {
     dispatch({
         type: actionTypes.REQUEST_DELETE_RESOURCE,
         payload: resource,
     })
-    dispatch(
-        showConfirmationSnackBar('Do you really want to delete this resource?')
-    )
+    dispatch(showConfirmationSnackBar(confirmationMessage))
 }
 
 export const deleteResourceStart = () => ({

--- a/src/redux/actions/resource.js
+++ b/src/redux/actions/resource.js
@@ -16,7 +16,11 @@ import {
     resetPagination,
     setPagination,
 } from './pagination'
-import { showSuccessSnackBar, showErrorSnackBar } from './feedback'
+import {
+    showSuccessSnackBar,
+    showErrorSnackBar,
+    showConfirmationSnackBar,
+} from './feedback'
 import humanReadableErrorMessage from '../../utils/humanReadableErrorMessage'
 
 export const actionTypes = {
@@ -28,6 +32,7 @@ export const actionTypes = {
     SHOW_SHARING_SETTINGS: 'SHOW_SHARING_SETTINGS',
     EDIT_RESOURCE: 'EDIT_RESOURCE',
     ADD_RESOURCE: 'ADD_RESOURCE',
+    REQUEST_DELETE_RESOURCE: 'REQUEST_DELETE_RESOURCE',
     DELETE_RESOURCE_START: 'DELETE_RESOURCE_START',
     DELETE_RESOURCE_SUCCESS: 'DELETE_RESOURCE_SUCCESS',
     DELETE_RESOURCE_ERROR: 'DELETE_RESOURCE_ERROR',
@@ -178,6 +183,20 @@ export const addResource = resource => ({
     payload: resource,
 })
 
+/**
+ * Used to get a confirmation from the user
+ * @return {Object}
+ */
+export const requestDeleteResource = resource => dispatch => {
+    dispatch({
+        type: actionTypes.REQUEST_DELETE_RESOURCE,
+        payload: resource,
+    })
+    dispatch(
+        showConfirmationSnackBar('Do you really want to delete this resource?')
+    )
+}
+
 export const deleteResourceStart = () => ({
     type: actionTypes.DELETE_RESOURCE_START,
 })
@@ -208,10 +227,12 @@ export const deleteResourceErrorWithFeedback = error => dispatch => {
     dispatch(deleteResourceError())
 }
 
-export const deleteResource = resource => dispatch => {
+export const deleteResource = () => (dispatch, getState) => {
     dispatch(deleteResourceStart())
-
-    return sendDeleteResourceRequest(resource.id)
+    const {
+        resource: { selectedResource },
+    } = getState()
+    return sendDeleteResourceRequest(selectedResource.id)
         .then(() => {
             dispatch(deleteResourceSuccessWithFeedback())
             dispatch(loadResources())

--- a/src/redux/reducers/__tests__/resource.test.js
+++ b/src/redux/reducers/__tests__/resource.test.js
@@ -21,15 +21,14 @@ describe('Reducer - resource', () => {
         expect(resource()).toEqual(defaultState)
     })
 
-    it('should set loading to true and clear the collection when loading resources', () => {
+    it('should set loading to true when loading resources', () => {
         const action = loadingResourcesStart()
         const preState = {
             ...defaultState,
-            collection: [1, 2, 3],
             loading: false,
         }
         const postState = resource(preState, action)
-        const expectedState = { ...preState, collection: [], loading: true }
+        const expectedState = { ...preState, loading: true }
 
         expect(postState).toEqual(expectedState)
     })

--- a/src/redux/reducers/__tests__/standardReport.test.js
+++ b/src/redux/reducers/__tests__/standardReport.test.js
@@ -27,16 +27,14 @@ describe('Reducer - standardReport', function() {
             LOADING_STANDARD_REPORTS_ERROR,
         } = actionTypes
 
-        it('should start loading and clear the reports collection', function() {
+        it('should start loading', function() {
             const action = { type: LOADING_STANDARD_REPORTS_START }
             const preState = {
                 ...defaultState,
-                reports: [1, 2, 3],
                 loading: false,
             }
             const expected = {
                 ...defaultState,
-                reports: [],
                 loading: true,
             }
             const actual = standardReport(preState, action)

--- a/src/redux/reducers/resource.js
+++ b/src/redux/reducers/resource.js
@@ -13,10 +13,14 @@ export const defaultState = {
 
 export const resource = (state = defaultState, { type, payload } = {}) => {
     switch (type) {
+        case actionTypes.REQUEST_DELETE_RESOURCE:
+            return {
+                ...state,
+                selectedResource: payload,
+            }
         case actionTypes.LOADING_RESOURCES_START:
             return {
                 ...state,
-                collection: [],
                 loading: true,
             }
 

--- a/src/redux/reducers/standardReport.js
+++ b/src/redux/reducers/standardReport.js
@@ -37,7 +37,6 @@ export const standardReport = (state = defaultState, action = {}) => {
         case actionTypes.LOADING_STANDARD_REPORTS_START:
             return {
                 ...state,
-                reports: [],
                 loading: true,
             }
 


### PR DESCRIPTION
- Lists are no longer cleared when loading. Instead the `SearchablePagedList` component makes sure to not render rows when the list is loading. I've done this to better deal with a failing delete scenario. So now, for example, if we try to delete an item, loading starts, and then if it fails, loading stops, and the original list is displayed.
- I also introduced a confirmation step in the delete resource process
- And also prevented the list from reloading when re-entering the page/route