### PR TITLE
refactor: router constants and implementation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,21 +1,22 @@
-import React, { PureComponent } from 'react'
-import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
-import D2UIApp from '@dhis2/d2-ui-app'
-import HeaderBar from '@dhis2/d2-ui-header-bar'
-import { Sidebar, mui3theme } from '@dhis2/d2-ui-core'
-import { connect } from 'react-redux'
-import { loadPeriodTypes } from './redux/actions/reportPeriod'
-import { loadOrganisationUnits } from './redux/actions/organisationUnits'
-import { loadDataSetOptions } from './redux/actions/dataSet'
-import AppRouter from './components/AppRouter'
-import { Loader } from './components/feedback/Loader'
-import AppContext from './pages/AppContext'
-import { sections } from './config/sections.config'
 import {
     MuiThemeProvider as Mui3ThemeProvider,
     createMuiTheme as createMui3Theme,
 } from '@material-ui/core/styles'
+import { Sidebar, mui3theme } from '@dhis2/d2-ui-core'
+import { connect } from 'react-redux'
+import D2UIApp from '@dhis2/d2-ui-app'
+import HeaderBar from '@dhis2/d2-ui-header-bar'
+import PropTypes from 'prop-types'
+import React, { PureComponent } from 'react'
+
+import { Loader } from './components/feedback/Loader'
+import { loadDataSetOptions } from './redux/actions/dataSet'
+import { loadOrganisationUnits } from './redux/actions/organisationUnits'
+import { loadPeriodTypes } from './redux/actions/reportPeriod'
+import { sectionOrder, sections } from './config/sections.config'
+import AppContext from './pages/AppContext'
+import AppRouter from './components/AppRouter'
 
 const MUI3Theme = createMui3Theme(mui3theme)
 
@@ -49,13 +50,15 @@ class App extends PureComponent {
     render() {
         // is not "marked" as required but it's used by Sidebar
         const nonOnChangeSection = () => null
-        const sidebarSections = sections.map(section =>
-            Object.assign(section, {
+        const sidebarSections = sectionOrder.map(sectionKey => {
+            const section = sections[sectionKey]
+            return {
+                ...section,
                 icon: section.info.icon,
                 label: section.info.label,
                 containerElement: <Link to={section.path} />,
-            })
-        )
+            }
+        })
 
         return (
             <AppContext.Provider value={this.getContext()}>

--- a/src/components/AppRouter.js
+++ b/src/components/AppRouter.js
@@ -1,5 +1,6 @@
 import { Route, Switch } from 'react-router-dom'
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import {
     DATA_SET_REPORT_SECTION_KEY,
@@ -18,51 +19,57 @@ import AppContext from '../pages/AppContext'
 import Home from '../pages/home/Home'
 import NoMatch from './NoMatch'
 
-const AppRouter = () => (
+const AppRouter = ({ d2 }) => (
+    <main>
+        <Switch>
+            <Route key="home" exact path="/" component={Home} />
+            <Route
+                exact
+                key={STANDARD_REPORT_SECTION_KEY}
+                path={sections[STANDARD_REPORT_SECTION_KEY].path}
+                render={() => <StandardReport d2={d2} />}
+            />
+            <Route
+                exact
+                key={DATA_SET_REPORT_SECTION_KEY}
+                path={sections[DATA_SET_REPORT_SECTION_KEY].path}
+                component={DataSetReport}
+            />
+            <Route
+                exact
+                key={REPORTING_RATE_SUMMARY_SECTION_KEY}
+                path={sections[REPORTING_RATE_SUMMARY_SECTION_KEY].path}
+                component={ReportingRateSummary}
+            />
+            <Route
+                exact
+                key={RESOURCE_SECTION_KEY}
+                path={sections[RESOURCE_SECTION_KEY].path}
+                render={() => <Resource d2={d2} />}
+            />
+            <Route
+                exact
+                key={ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY}
+                path={
+                    sections[ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY]
+                        .path
+                }
+                component={OrganisationUnitDistributionReport}
+            />
+            <Route key="no-match-route" component={NoMatch} />
+        </Switch>
+    </main>
+)
+
+AppRouter.propTypes = {
+    d2: PropTypes.object.isRequired,
+}
+
+const AppRouterWithD2 = () => (
     <AppContext.Consumer>
-        {({ d2 }) => (
-            <main>
-                <Switch>
-                    <Route key="home" exact path="/" component={Home} />
-                    <Route
-                        exact
-                        key={STANDARD_REPORT_SECTION_KEY}
-                        path={sections[STANDARD_REPORT_SECTION_KEY].path}
-                        render={() => <StandardReport d2={d2} />}
-                    />
-                    <Route
-                        exact
-                        key={DATA_SET_REPORT_SECTION_KEY}
-                        path={sections[DATA_SET_REPORT_SECTION_KEY].path}
-                        component={DataSetReport}
-                    />
-                    <Route
-                        exact
-                        key={REPORTING_RATE_SUMMARY_SECTION_KEY}
-                        path={sections[REPORTING_RATE_SUMMARY_SECTION_KEY].path}
-                        component={ReportingRateSummary}
-                    />
-                    <Route
-                        exact
-                        key={RESOURCE_SECTION_KEY}
-                        path={sections[RESOURCE_SECTION_KEY].path}
-                        render={() => <Resource d2={d2} />}
-                    />
-                    <Route
-                        exact
-                        key={ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY}
-                        path={
-                            sections[
-                                ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY
-                            ].path
-                        }
-                        component={OrganisationUnitDistributionReport}
-                    />
-                    <Route key="no-match-route" component={NoMatch} />
-                </Switch>
-            </main>
-        )}
+        {({ d2 }) => <AppRouter d2={d2} />}
     </AppContext.Consumer>
 )
 
-export default AppRouter
+export default AppRouterWithD2
+export { AppRouter as AppRouterComponent }

--- a/src/components/AppRouter.js
+++ b/src/components/AppRouter.js
@@ -1,58 +1,114 @@
-/* React */
+import { Route, Switch } from 'react-router-dom'
 import React from 'react'
 
-/* React Router */
-import { Route, Switch } from 'react-router-dom'
-
-/* App components */
+import {
+    DATA_SET_REPORT_SECTION_KEY,
+    ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY,
+    REPORTING_RATE_SUMMARY_SECTION_KEY,
+    RESOURCE_SECTION_KEY,
+    STANDARD_REPORT_SECTION_KEY,
+} from '../config/sections.config'
+import { DataSetReport } from '../pages/DataSetReport'
+import { OrganisationUnitDistributionReport } from '../pages/OrganisationUnitDistributionReport'
+import { ReportingRateSummary } from '../pages/ReportingRateSummary'
+import { Resource } from '../pages/Resource'
+import { StandardReport } from '../pages/StandardReport'
+import { sections } from '../conf../../config/sections.config'
+import AppContext from '../pages/AppContext'
 import Home from '../pages/home/Home'
 import NoMatch from './NoMatch'
 
-/* App context */
-import AppContext from '../pages/AppContext'
+const AppRouter = () => (
+    <AppContext.Consumer>
+        {({ d2 }) => (
+            <main>
+                <Switch>
+                    <Route
+                        key="home"
+                        exact
+                        path="/"
+                        render={() => <Home sectionKey="home" />}
+                    />
+                    <Route
+                        exact
+                        key={STANDARD_REPORT_SECTION_KEY}
+                        path={sections[STANDARD_REPORT_SECTION_KEY].path}
+                        render={() => <StandardReport d2={d2} />}
+                    />
+                    <Route
+                        exact
+                        key={DATA_SET_REPORT_SECTION_KEY}
+                        path={sections[DATA_SET_REPORT_SECTION_KEY].path}
+                        component={DataSetReport}
+                    />
+                    <Route
+                        exact
+                        key={REPORTING_RATE_SUMMARY_SECTION_KEY}
+                        path={sections[REPORTING_RATE_SUMMARY_SECTION_KEY].path}
+                        component={ReportingRateSummary}
+                    />
+                    <Route
+                        exact
+                        key={RESOURCE_SECTION_KEY}
+                        path={sections[RESOURCE_SECTION_KEY].path}
+                        render={() => <Resource d2={d2} />}
+                    />
+                    <Route
+                        exact
+                        key={ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY}
+                        path={
+                            sections[
+                                ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY
+                            ].path
+                        }
+                        component={OrganisationUnitDistributionReport}
+                    />
+                    <Route key="no-match-route" component={NoMatch} />
+                </Switch>
+            </main>
+        )}
+    </AppContext.Consumer>
+)
 
-/* App configs */
-import { sections } from '../conf../../config/sections.config'
+//const _AppRouter = () => {
+//const routes = sections.map(section => {
+//const routeRender = () => {
+//const Page = section.component
+//return (
+//<AppContext.Consumer>
+//{appContext => (
+//<Page
+//d2={appContext.d2}
+//sectionKey={section.key}
+//{...appContext.pageState}
+///>
+//)}
+//</AppContext.Consumer>
+//)
+//}
+//return (
+//<Route
+//key={section.key}
+//exact
+//path={section.path}
+//render={routeRender}
+///>
+//)
+//})
 
-const AppRouter = () => {
-    const routes = sections.map(section => {
-        const routeRender = () => {
-            const Page = section.component
-            return (
-                <AppContext.Consumer>
-                    {appContext => (
-                        <Page
-                            d2={appContext.d2}
-                            sectionKey={section.key}
-                            {...appContext.pageState}
-                        />
-                    )}
-                </AppContext.Consumer>
-            )
-        }
-        return (
-            <Route
-                key={section.key}
-                exact
-                path={section.path}
-                render={routeRender}
-            />
-        )
-    })
+//[> Home route <]
+//const homeRouteRender = () => <Home sectionKey="home" />
 
-    /* Home route */
-    const homeRouteRender = () => <Home sectionKey="home" />
+//routes.push(<Route key="home" exact path="/" render={homeRouteRender} />)
 
-    routes.push(<Route key="home" exact path="/" render={homeRouteRender} />)
+//[> No Match Route <]
+//routes.push(<Route key="no-match-route" component={NoMatch} />)
 
-    /* No Match Route */
-    routes.push(<Route key="no-match-route" component={NoMatch} />)
-
-    return (
-        <main>
-            <Switch>{routes}</Switch>
-        </main>
-    )
-}
+//return (
+//<main>
+//<Switch>{routes}</Switch>
+//</main>
+//)
+//}
 
 export default AppRouter

--- a/src/components/AppRouter.js
+++ b/src/components/AppRouter.js
@@ -23,12 +23,7 @@ const AppRouter = () => (
         {({ d2 }) => (
             <main>
                 <Switch>
-                    <Route
-                        key="home"
-                        exact
-                        path="/"
-                        render={() => <Home sectionKey="home" />}
-                    />
+                    <Route key="home" exact path="/" component={Home} />
                     <Route
                         exact
                         key={STANDARD_REPORT_SECTION_KEY}
@@ -69,46 +64,5 @@ const AppRouter = () => (
         )}
     </AppContext.Consumer>
 )
-
-//const _AppRouter = () => {
-//const routes = sections.map(section => {
-//const routeRender = () => {
-//const Page = section.component
-//return (
-//<AppContext.Consumer>
-//{appContext => (
-//<Page
-//d2={appContext.d2}
-//sectionKey={section.key}
-//{...appContext.pageState}
-///>
-//)}
-//</AppContext.Consumer>
-//)
-//}
-//return (
-//<Route
-//key={section.key}
-//exact
-//path={section.path}
-//render={routeRender}
-///>
-//)
-//})
-
-//[> Home route <]
-//const homeRouteRender = () => <Home sectionKey="home" />
-
-//routes.push(<Route key="home" exact path="/" render={homeRouteRender} />)
-
-//[> No Match Route <]
-//routes.push(<Route key="no-match-route" component={NoMatch} />)
-
-//return (
-//<main>
-//<Switch>{routes}</Switch>
-//</main>
-//)
-//}
 
 export default AppRouter

--- a/src/components/SectionHeadline.js
+++ b/src/components/SectionHeadline.js
@@ -1,7 +1,9 @@
-import React from 'react'
 import PropTypes from 'prop-types'
-import PageHelper from '../components/PageHelper'
+import React from 'react'
+
 import { getDocsUrl } from '../utils/getDocsUrl'
+import AppContext from '../pages/AppContext'
+import PageHelper from '../components/PageHelper'
 
 export const SectionHeadline = props => (
     <h1>
@@ -17,7 +19,13 @@ export const SectionHeadline = props => (
             </span>
         )}
         {props.label}
-        <PageHelper url={getDocsUrl(props.systemVersion, props.sectionKey)} />
+        <AppContext.Consumer>
+            {({ d2 }) => (
+                <PageHelper
+                    url={getDocsUrl(d2.system.version, props.sectionKey)}
+                />
+            )}
+        </AppContext.Consumer>
         <style jsx>{`
             .back-button {
                 cursor: pointer;
@@ -31,7 +39,6 @@ SectionHeadline.propTypes = {
     label: PropTypes.string.isRequired,
     showBackButton: PropTypes.bool,
     sectionKey: PropTypes.string.isRequired,
-    systemVersion: PropTypes.object.isRequired,
     onBackClick: PropTypes.func,
 }
 

--- a/src/components/__tests__/AppRouter.test.js
+++ b/src/components/__tests__/AppRouter.test.js
@@ -1,37 +1,24 @@
-/* eslint-disable */
+import { Route, Switch } from 'react-router-dom'
 import React from 'react'
+
 import { shallow } from 'enzyme'
 
-import AppRouter from '../AppRouter'
-import { Route, Switch } from 'react-router-dom'
+import { AppRouterComponent as AppRouter } from '../AppRouter'
+import { sectionOrder } from '../../config/sections.config'
 
-import { sections } from '../../config/sections.config'
+jest.mock('@dhis2/d2-ui-org-unit-tree', () => ({ OrgUnitTree: 'OrgUnitTree' }))
 
-const pageState = {}
-
-jest.mock('@dhis2/d2-ui-org-unit-tree', () => ({
-    OrgUnitTree: 'OrgUnitTree',
-}))
-
-const ownShallow = () => {
-    return shallow(<AppRouter pageState={pageState} />, {
-        disableLifecycleMethods: true,
-    })
-}
-
-/* Mocks */
 jest.mock('@dhis2/d2-ui-org-unit-tree', () => 'OrgUnitTree')
+
+const ownShallow = () => shallow(<AppRouter d2={{}} />)
 
 it('AppRouter renders without crashing', () => {
     ownShallow()
 })
 
-it('AppRouter renders a Switch', () => {
-    const wrapper = ownShallow()
-    expect(wrapper.find(Switch)).toHaveLength(1)
-})
-
 it('AppRouter renders the correct number of Route', () => {
     const wrapper = ownShallow()
-    expect(wrapper.find(Route)).toHaveLength(sections.length + 2) // Pages plus home and no match route
+
+    // Pages plus home and no match route
+    expect(wrapper.find(Route)).toHaveLength(sectionOrder.length + 2)
 })

--- a/src/components/__tests__/MenuElement.test.js
+++ b/src/components/__tests__/MenuElement.test.js
@@ -1,19 +1,26 @@
 /* eslint-disable */
-import React from 'react'
-import { shallow } from 'enzyme'
 import Paper from '@material-ui/core/Paper'
-import MenuElement from '../MenuElement'
+import React from 'react'
 
-import { sections } from '../../config/sections.config'
+import { shallow } from 'enzyme'
+
+import {
+    STANDARD_REPORT_SECTION_KEY,
+    sections,
+} from '../../config/sections.config'
+import MenuElement from '../MenuElement'
 
 jest.mock('@dhis2/d2-ui-org-unit-tree', () => ({
     OrgUnitTree: 'OrgUnitTree',
 }))
 
 const ownShallow = () => {
-    return shallow(<MenuElement entry={sections[0].info} />, {
-        disableLifecycleMethods: true,
-    })
+    return shallow(
+        <MenuElement entry={sections[STANDARD_REPORT_SECTION_KEY].info} />,
+        {
+            disableLifecycleMethods: true,
+        }
+    )
 }
 
 /* Mocks */

--- a/src/config/sections.config.js
+++ b/src/config/sections.config.js
@@ -1,9 +1,4 @@
 import i18n from '@dhis2/d2-i18n'
-import { StandardReport } from '../pages/StandardReport'
-import { DataSetReport } from '../pages/DataSetReport'
-import { ReportingRateSummary } from '../pages/ReportingRateSummary'
-import { OrganisationUnitDistributionReport } from '../pages/OrganisationUnitDistributionReport'
-import { Resource } from '../pages/Resource'
 
 export const STANDARD_REPORT_SECTION_KEY = 'standard-report'
 export const DATA_SET_REPORT_SECTION_KEY = 'data-set-report'
@@ -13,13 +8,18 @@ export const ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY =
     'organisation-unit-distribution-report'
 export const DATA_APPROVAL_SECTION_KEY = 'data-approval'
 
-export const DEBOUNCE_DELAY = 500
+export const sectionOrder = [
+    STANDARD_REPORT_SECTION_KEY,
+    DATA_SET_REPORT_SECTION_KEY,
+    REPORTING_RATE_SUMMARY_SECTION_KEY,
+    RESOURCE_SECTION_KEY,
+    ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY,
+]
 
-export const sections = [
-    {
+export const sections = {
+    [STANDARD_REPORT_SECTION_KEY]: {
         key: STANDARD_REPORT_SECTION_KEY,
         path: '/standard-report',
-        component: StandardReport,
         info: {
             label: i18n.t('Standard Report'),
             icon: i18n.t('bar_chart'),
@@ -30,10 +30,9 @@ export const sections = [
             docs: 'using_reporting_standard_reports',
         },
     },
-    {
+    [DATA_SET_REPORT_SECTION_KEY]: {
         key: DATA_SET_REPORT_SECTION_KEY,
         path: '/data-set-report',
-        component: DataSetReport,
         info: {
             label: i18n.t('Data Set Report'),
             icon: 'assignment',
@@ -44,10 +43,9 @@ export const sections = [
             docs: 'using_reporting_dataset_reports',
         },
     },
-    {
+    [REPORTING_RATE_SUMMARY_SECTION_KEY]: {
         key: REPORTING_RATE_SUMMARY_SECTION_KEY,
         path: '/reporting-rate-summary',
-        component: ReportingRateSummary,
         info: {
             label: i18n.t('Reporting Rate Summary'),
             description: i18n.t(
@@ -58,10 +56,9 @@ export const sections = [
             docs: 'using_reporting_reporting_rate_summary',
         },
     },
-    {
+    [RESOURCE_SECTION_KEY]: {
         key: RESOURCE_SECTION_KEY,
         path: '/resource',
-        component: Resource,
         info: {
             label: i18n.t('Resource'),
             description: i18n.t(
@@ -72,10 +69,9 @@ export const sections = [
             docs: 'using_reporting_resources',
         },
     },
-    {
+    [ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY]: {
         key: ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY,
         path: '/organisation-unit-distribution-report',
-        component: OrganisationUnitDistributionReport,
         info: {
             label: i18n.t('Organisation Unit Distribution Report'),
             description: i18n.t(
@@ -86,15 +82,4 @@ export const sections = [
             docs: 'using_reporting_orgunit_distribution_reports',
         },
     },
-]
-
-export const getDocsKeyForSection = sectionKey => {
-    for (let i = 0; i < sections.length; i++) {
-        const section = sections[i]
-        if (section.key === sectionKey) {
-            return section.info.docs
-        }
-    }
-
-    return ''
 }

--- a/src/config/sections.config.js
+++ b/src/config/sections.config.js
@@ -19,7 +19,7 @@ export const sectionOrder = [
 export const sections = {
     [STANDARD_REPORT_SECTION_KEY]: {
         key: STANDARD_REPORT_SECTION_KEY,
-        path: '/standard-report',
+        path: `/${STANDARD_REPORT_SECTION_KEY}`,
         info: {
             label: i18n.t('Standard Report'),
             icon: i18n.t('bar_chart'),
@@ -32,7 +32,7 @@ export const sections = {
     },
     [DATA_SET_REPORT_SECTION_KEY]: {
         key: DATA_SET_REPORT_SECTION_KEY,
-        path: '/data-set-report',
+        path: `/${DATA_SET_REPORT_SECTION_KEY}`,
         info: {
             label: i18n.t('Data Set Report'),
             icon: 'assignment',
@@ -45,7 +45,7 @@ export const sections = {
     },
     [REPORTING_RATE_SUMMARY_SECTION_KEY]: {
         key: REPORTING_RATE_SUMMARY_SECTION_KEY,
-        path: '/reporting-rate-summary',
+        path: `/${REPORTING_RATE_SUMMARY_SECTION_KEY}`,
         info: {
             label: i18n.t('Reporting Rate Summary'),
             description: i18n.t(
@@ -58,7 +58,7 @@ export const sections = {
     },
     [RESOURCE_SECTION_KEY]: {
         key: RESOURCE_SECTION_KEY,
-        path: '/resource',
+        path: `/${RESOURCE_SECTION_KEY}`,
         info: {
             label: i18n.t('Resource'),
             description: i18n.t(
@@ -71,7 +71,7 @@ export const sections = {
     },
     [ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY]: {
         key: ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY,
-        path: '/organisation-unit-distribution-report',
+        path: `/${ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY}`,
         info: {
             label: i18n.t('Organisation Unit Distribution Report'),
             description: i18n.t(

--- a/src/pages/DataSetReport.js
+++ b/src/pages/DataSetReport.js
@@ -1,21 +1,24 @@
-import React from 'react'
-import PropTypes from 'prop-types'
 import Paper from '@material-ui/core/Paper'
-import { Snackbar } from '../components/feedback/Snackbar'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import {
+    DATA_SET_REPORT_SECTION_KEY,
+    sections,
+} from '../config/sections.config'
 import { SectionHeadline } from '../components/SectionHeadline'
+import { Snackbar } from '../components/feedback/Snackbar'
+import { connectDataSetReport } from './data-set-report/connectDataSetReport'
+import { container } from '../utils/styles/shared.js'
+import { reportContent } from '../utils/react/propTypes'
 import DataSetReportOutput from './data-set-report/DataSetReportOutput'
 import Form from './data-set-report/Form'
-import { connectDataSetReport } from './data-set-report/connectDataSetReport'
-import i18n from '@dhis2/d2-i18n'
-import { reportContent } from '../utils/react/propTypes'
-import { container } from '../utils/styles/shared.js'
 
 const DataSetReport = props => (
     <div>
         <SectionHeadline
-            label={i18n.t('Data Set Report')}
-            systemVersion={props.d2.system.version}
-            sectionKey={props.sectionKey}
+            label={sections[DATA_SET_REPORT_SECTION_KEY].info.label}
+            sectionKey={DATA_SET_REPORT_SECTION_KEY}
         />
         <Paper className={container.className}>
             <div id="data-set-report-form">
@@ -43,8 +46,6 @@ const DataSetReport = props => (
 )
 
 DataSetReport.propTypes = {
-    d2: PropTypes.object.isRequired,
-    sectionKey: PropTypes.string.isRequired,
     fileUrls: PropTypes.array.isRequired,
     isHtmlReport: PropTypes.bool.isRequired,
     reportContent: reportContent.isRequired,

--- a/src/pages/OrganisationUnitDistributionReport.js
+++ b/src/pages/OrganisationUnitDistributionReport.js
@@ -1,15 +1,19 @@
-import React from 'react'
-import PropTypes from 'prop-types'
 import Paper from '@material-ui/core/Paper'
-import i18n from '@dhis2/d2-i18n'
-import TabularReport from '../components/TabularReport'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import { Form } from './organisation-unit-distribution-report/Form'
+import {
+    ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY,
+    sections,
+} from '../config/sections.config'
+import { SectionHeadline } from '../components/SectionHeadline'
 import { Snackbar } from '../components/feedback/Snackbar'
 import { connectOrganisationUnitDistributionReport } from './organisation-unit-distribution-report/connectOrganisationUnitDistributionReport'
-import { SectionHeadline } from '../components/SectionHeadline'
-import { Form } from './organisation-unit-distribution-report/Form'
-import BarChart from '../components/BarChart'
-import { reportContent } from '../utils/react/propTypes'
 import { container } from '../utils/styles/shared.js'
+import { reportContent } from '../utils/react/propTypes'
+import BarChart from '../components/BarChart'
+import TabularReport from '../components/TabularReport'
 
 class OrganisationUnitDistributionReport extends React.Component {
     componentDidMount() {
@@ -22,9 +26,14 @@ class OrganisationUnitDistributionReport extends React.Component {
         return (
             <div>
                 <SectionHeadline
-                    label={i18n.t('Organisation Unit Distribution Report')}
-                    systemVersion={this.props.d2.system.version}
-                    sectionKey={this.props.sectionKey}
+                    label={
+                        sections[
+                            ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY
+                        ].info.label
+                    }
+                    sectionKey={
+                        ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY
+                    }
                 />
                 <Paper className={container.className}>
                     <Form
@@ -56,8 +65,6 @@ class OrganisationUnitDistributionReport extends React.Component {
 }
 
 OrganisationUnitDistributionReport.propTypes = {
-    d2: PropTypes.object.isRequired,
-    sectionKey: PropTypes.string.isRequired,
     isActionEnabled: PropTypes.bool.isRequired,
     shouldShowChart: PropTypes.bool.isRequired,
     loading: PropTypes.bool.isRequired,

--- a/src/pages/ReportingRateSummary.js
+++ b/src/pages/ReportingRateSummary.js
@@ -1,21 +1,24 @@
-import React from 'react'
-import PropTypes from 'prop-types'
 import Paper from '@material-ui/core/Paper'
-import i18n from '@dhis2/d2-i18n'
-import { Snackbar } from '../components/feedback/Snackbar'
-import TabularReport from '../components/TabularReport'
-import { SectionHeadline } from '../components/SectionHeadline'
-import { connectReportingRateSummary } from './reporting-rate-summary/connectReportingRateSummary'
+import PropTypes from 'prop-types'
+import React from 'react'
+
 import { Form } from './reporting-rate-summary/Form'
-import { reportContent } from '../utils/react/propTypes'
+import {
+    REPORTING_RATE_SUMMARY_SECTION_KEY,
+    sections,
+} from '../config/sections.config'
+import { SectionHeadline } from '../components/SectionHeadline'
+import { Snackbar } from '../components/feedback/Snackbar'
+import { connectReportingRateSummary } from './reporting-rate-summary/connectReportingRateSummary'
 import { container } from '../utils/styles/shared.js'
+import { reportContent } from '../utils/react/propTypes'
+import TabularReport from '../components/TabularReport'
 
 const ReportingRateSummary = props => (
     <div>
         <SectionHeadline
-            label={i18n.t('Reporting rate summary')}
-            systemVersion={props.d2.system.version}
-            sectionKey={props.sectionKey}
+            label={sections[REPORTING_RATE_SUMMARY_SECTION_KEY].info.label}
+            sectionKey={REPORTING_RATE_SUMMARY_SECTION_KEY}
         />
         <Paper className={container.className}>
             <Form
@@ -34,8 +37,6 @@ const ReportingRateSummary = props => (
 )
 
 ReportingRateSummary.propTypes = {
-    d2: PropTypes.object.isRequired,
-    sectionKey: PropTypes.string.isRequired,
     isActionEnabled: PropTypes.bool.isRequired,
     loadReportData: PropTypes.func.isRequired,
     reportContent: reportContent.isRequired,

--- a/src/pages/Resource.js
+++ b/src/pages/Resource.js
@@ -1,13 +1,15 @@
-import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Snackbar } from '../components/feedback/Snackbar'
-import SearchablePagedList from '../components/SearchablePagedList'
+import i18n from '@dhis2/d2-i18n'
+
+import { RESOURCE_SECTION_KEY, sections } from '../config/sections.config'
 import { SectionHeadline } from '../components/SectionHeadline'
-import { contextMenuIcons, resourceActions } from '../utils/resource/constants'
+import { Snackbar } from '../components/feedback/Snackbar'
 import { connectResource } from './resource/connectResource'
+import { contextMenuIcons, resourceActions } from '../utils/resource/constants'
 import { showContextAction } from './resource/helper'
 import ResourceActions from './resource/ResourceActions'
+import SearchablePagedList from '../components/SearchablePagedList'
 
 const createContextMenuOptions = props => ({
     [resourceActions.VIEW]: props.viewResource,
@@ -36,9 +38,8 @@ class Resource extends React.Component {
         return (
             <div>
                 <SectionHeadline
-                    label={i18n.t('Resource')}
-                    systemVersion={this.props.d2.system.version}
-                    sectionKey={this.props.sectionKey}
+                    label={sections[RESOURCE_SECTION_KEY].info.label}
+                    sectionKey={RESOURCE_SECTION_KEY}
                 />
                 <div id="resource-content">
                     <SearchablePagedList
@@ -78,7 +79,6 @@ class Resource extends React.Component {
 
 Resource.propTypes = {
     d2: PropTypes.object.isRequired,
-    sectionKey: PropTypes.string.isRequired,
     open: PropTypes.bool.isRequired,
     loadingResources: PropTypes.bool.isRequired,
     search: PropTypes.string.isRequired,

--- a/src/pages/StandardReport.js
+++ b/src/pages/StandardReport.js
@@ -1,18 +1,23 @@
-import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Snackbar } from '../components/feedback/Snackbar'
-import SearchablePagedList from '../components/SearchablePagedList'
-import { SectionHeadline } from '../components/SectionHeadline'
-import connectStandardReport from './standard-report/connectStandardReport'
-import { showContextAction } from './standard-report/helper'
-import { ConnectedReportParams } from './standard-report/ReportParams'
+import i18n from '@dhis2/d2-i18n'
+
 import {
     CONTEXT_MENU_ACTION,
     CONTEXT_MENU_ICONS,
 } from './standard-report/standard.report.conf'
+import { ConnectedReportParams } from './standard-report/ReportParams'
+import {
+    STANDARD_REPORT_SECTION_KEY,
+    sections,
+} from '../config/sections.config'
+import { SectionHeadline } from '../components/SectionHeadline'
+import { Snackbar } from '../components/feedback/Snackbar'
+import { showContextAction } from './standard-report/helper'
+import SearchablePagedList from '../components/SearchablePagedList'
 import StandardReportActions from './standard-report/StandardReportActions'
 import StyledHtmlReport from './standard-report/StyledHtmlReport'
+import connectStandardReport from './standard-report/connectStandardReport'
 
 const createContextMenuOptions = props => ({
     [CONTEXT_MENU_ACTION.CREATE]: props.createReport,
@@ -41,11 +46,10 @@ class StandardReport extends React.Component {
         return (
             <div>
                 <SectionHeadline
-                    label={i18n.t('Standard Report')}
+                    label={sections[STANDARD_REPORT_SECTION_KEY].info.label}
                     showBackButton={!!this.props.reportData}
                     onBackClick={this.props.hideReportData}
-                    systemVersion={this.props.d2.system.version}
-                    sectionKey={this.props.sectionKey}
+                    sectionKey={STANDARD_REPORT_SECTION_KEY}
                 />
                 <div id="std-report-content">
                     <SearchablePagedList
@@ -96,7 +100,6 @@ class StandardReport extends React.Component {
 
 StandardReport.propTypes = {
     d2: PropTypes.object.isRequired,
-    sectionKey: PropTypes.string.isRequired,
     loading: PropTypes.bool.isRequired,
     pager: PropTypes.object.isRequired,
     reports: PropTypes.array.isRequired,

--- a/src/pages/home/Home.js
+++ b/src/pages/home/Home.js
@@ -1,26 +1,29 @@
-import React from 'react'
 import { Link } from 'react-router-dom'
+import React from 'react'
 
+import { sectionOrder, sections } from '../../config/sections.config'
 import MenuElement from '../../components/MenuElement'
 
-import { sections } from '../../config/sections.config'
-
 const Home = () => {
-    const menuCards = sections.map(element => (
-        <div key={element.key} className="col-sm-12 col-md-6 col-lg-4">
-            <Link to={element.path} className="menu-card-link">
-                <MenuElement entry={element.info} />
-            </Link>
-            <style jsx>{`
-                div {
-                    margin-bottom: 8px;
-                }
-                div :global(.menu-card-link) {
-                    text-decoration: none !important;
-                }
-            `}</style>
-        </div>
-    ))
+    const menuCards = sectionOrder.map(sectionKey => {
+        const element = sections[sectionKey]
+
+        return (
+            <div key={element.key} className="col-sm-12 col-md-6 col-lg-4">
+                <Link to={element.path} className="menu-card-link">
+                    <MenuElement entry={element.info} />
+                </Link>
+                <style jsx>{`
+                    div {
+                        margin-bottom: 8px;
+                    }
+                    div :global(.menu-card-link) {
+                        text-decoration: none !important;
+                    }
+                `}</style>
+            </div>
+        )
+    })
 
     return (
         <div id={'menu-grid-id'} className="row">

--- a/src/pages/home/Home.test.js
+++ b/src/pages/home/Home.test.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme'
 import Home from './Home'
 import MenuElement from '../../components/MenuElement'
 
-import { sections } from '../../config/sections.config'
+import { sectionOrder } from '../../config/sections.config'
 
 jest.mock('@dhis2/d2-ui-org-unit-tree', () => ({
     OrgUnitTree: 'OrgUnitTree',
@@ -31,6 +31,6 @@ describe('Test <Home /> rendering:', () => {
     })
 
     it('Renders the correct number of elements.', () => {
-        expect(wrapper.find(MenuElement)).toHaveLength(sections.length)
+        expect(wrapper.find(MenuElement)).toHaveLength(sectionOrder.length)
     })
 })

--- a/src/utils/getDocsUrl.js
+++ b/src/utils/getDocsUrl.js
@@ -1,4 +1,4 @@
-import { getDocsKeyForSection } from '../config/sections.config'
+import { sections } from '../config/sections.config'
 
 export const DOCS_LINK = 'https://ci.dhis2.org/docs'
 export const DEFAULT_DOC_LANGUAGE = 'en'
@@ -21,9 +21,9 @@ const getDocsVersion = ({ major, minor, snapshot }) => {
 
 export const getDocsUrl = (systemVersion, sectionKey, lng) => {
     const docLng = lng || DEFAULT_DOC_LANGUAGE
-    return `${DOCS_LINK}/${getDocsVersion(
-        systemVersion
-    )}/${docLng}/user/html/${getDocsKeyForSection(sectionKey)}.html`
+    return `${DOCS_LINK}/${getDocsVersion(systemVersion)}/${docLng}/user/html/${
+        sections[sectionKey].info.docs
+    }.html`
 }
 
 export default getDocsUrl


### PR DESCRIPTION
# What I changed

1. I've moved the component rendering to the `AppRouter` component, where it belongs to.
1. Now there's no more passing through of the `sectionKey` as each section page component already knows which section it is, so it can make use of it directly. This simplifies the router quite a bit!
1. Also the configuration of sections and the section order are not mixed in one constant anymore, making it easier to access values.