### PR TITLE
Refactor/remove app context where possible

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,28 +8,18 @@ import { connect } from 'react-redux'
 import D2UIApp from '@dhis2/d2-ui-app'
 import HeaderBar from '@dhis2/d2-ui-header-bar'
 import PropTypes from 'prop-types'
-import React, { PureComponent } from 'react'
+import React, { Component } from 'react'
 
 import { Loader } from './components/feedback/Loader'
 import { loadDataSetOptions } from './redux/actions/dataSet'
 import { loadOrganisationUnits } from './redux/actions/organisationUnits'
 import { loadPeriodTypes } from './redux/actions/reportPeriod'
 import { sectionOrder, sections } from './config/sections.config'
-import AppContext from './pages/AppContext'
 import AppRouter from './components/AppRouter'
 
 const MUI3Theme = createMui3Theme(mui3theme)
 
-class App extends PureComponent {
-    constructor(props) {
-        super(props)
-
-        this.state = {
-            d2: props.d2,
-            pageState: {},
-        }
-    }
-
+class App extends Component {
     getChildContext() {
         return { d2: this.props.d2 }
     }
@@ -38,13 +28,6 @@ class App extends PureComponent {
         this.props.loadOrganisationUnits()
         this.props.loadPeriodTypes()
         this.props.loadDataSetOptions()
-    }
-
-    getContext() {
-        return {
-            d2: this.props.d2,
-            pageState: this.state.pageState,
-        }
     }
 
     render() {
@@ -61,23 +44,21 @@ class App extends PureComponent {
         })
 
         return (
-            <AppContext.Provider value={this.getContext()}>
-                <D2UIApp>
-                    <Mui3ThemeProvider theme={MUI3Theme}>
-                        <HeaderBar d2={this.props.d2} />
-                        <Sidebar
-                            sections={sidebarSections}
-                            onChangeSection={nonOnChangeSection}
-                            currentSection={this.props.currentSection}
-                        />
-                        <div className="content-wrapper">
-                            <div className="content-area">
-                                <AppRouter />
-                            </div>
+            <D2UIApp>
+                <Mui3ThemeProvider theme={MUI3Theme}>
+                    <HeaderBar d2={this.props.d2} />
+                    <Sidebar
+                        sections={sidebarSections}
+                        onChangeSection={nonOnChangeSection}
+                        currentSection={this.props.currentSection}
+                    />
+                    <div className="content-wrapper">
+                        <div className="content-area">
+                            <AppRouter />
                         </div>
-                        <Loader />
-                    </Mui3ThemeProvider>
-                </D2UIApp>
+                    </div>
+                    <Loader />
+                </Mui3ThemeProvider>
                 <style jsx>{`
                     .content-wrapper {
                         margin-left: 295px;
@@ -144,7 +125,7 @@ class App extends PureComponent {
                         width: 100% !important;
                     }
                 `}</style>
-            </AppContext.Provider>
+            </D2UIApp>
         )
     }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,7 @@ import { connect } from 'react-redux'
 import D2UIApp from '@dhis2/d2-ui-app'
 import HeaderBar from '@dhis2/d2-ui-header-bar'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 
 import { Loader } from './components/feedback/Loader'
 import { loadDataSetOptions } from './redux/actions/dataSet'
@@ -19,7 +19,7 @@ import AppRouter from './components/AppRouter'
 
 const MUI3Theme = createMui3Theme(mui3theme)
 
-class App extends Component {
+class App extends PureComponent {
     getChildContext() {
         return { d2: this.props.d2 }
     }

--- a/src/components/AppRouter.js
+++ b/src/components/AppRouter.js
@@ -1,10 +1,10 @@
 import { Route, Switch } from 'react-router-dom'
 import React from 'react'
-import PropTypes from 'prop-types'
+// import PropTypes from 'prop-types'
 
 import {
     DATA_SET_REPORT_SECTION_KEY,
-    ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY,
+    ORG_UNIT_DIST_REPORT_SECTION_KEY,
     REPORTING_RATE_SUMMARY_SECTION_KEY,
     RESOURCE_SECTION_KEY,
     STANDARD_REPORT_SECTION_KEY,
@@ -15,11 +15,10 @@ import { ReportingRateSummary } from '../pages/ReportingRateSummary'
 import { Resource } from '../pages/Resource'
 import { StandardReport } from '../pages/StandardReport'
 import { sections } from '../conf../../config/sections.config'
-import AppContext from '../pages/AppContext'
 import Home from '../pages/home/Home'
 import NoMatch from './NoMatch'
 
-const AppRouter = ({ d2 }) => (
+const AppRouter = () => (
     <main>
         <Switch>
             <Route key="home" exact path="/" component={Home} />
@@ -27,7 +26,7 @@ const AppRouter = ({ d2 }) => (
                 exact
                 key={STANDARD_REPORT_SECTION_KEY}
                 path={sections[STANDARD_REPORT_SECTION_KEY].path}
-                render={() => <StandardReport d2={d2} />}
+                component={StandardReport}
             />
             <Route
                 exact
@@ -45,15 +44,12 @@ const AppRouter = ({ d2 }) => (
                 exact
                 key={RESOURCE_SECTION_KEY}
                 path={sections[RESOURCE_SECTION_KEY].path}
-                render={() => <Resource d2={d2} />}
+                component={Resource}
             />
             <Route
                 exact
-                key={ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY}
-                path={
-                    sections[ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY]
-                        .path
-                }
+                key={ORG_UNIT_DIST_REPORT_SECTION_KEY}
+                path={sections[ORG_UNIT_DIST_REPORT_SECTION_KEY].path}
                 component={OrganisationUnitDistributionReport}
             />
             <Route key="no-match-route" component={NoMatch} />
@@ -61,15 +57,4 @@ const AppRouter = ({ d2 }) => (
     </main>
 )
 
-AppRouter.propTypes = {
-    d2: PropTypes.object.isRequired,
-}
-
-const AppRouterWithD2 = () => (
-    <AppContext.Consumer>
-        {({ d2 }) => <AppRouter d2={d2} />}
-    </AppContext.Consumer>
-)
-
-export default AppRouterWithD2
-export { AppRouter as AppRouterComponent }
+export default AppRouter

--- a/src/components/OrganisationUnitGroupSets.js
+++ b/src/components/OrganisationUnitGroupSets.js
@@ -69,6 +69,7 @@ export const OrganisationUnitGroupSets = ({
         groupSets.map(groupSet => (
             <OrganisationUnitGroupSetDropdown
                 groupSet={groupSet}
+                key={groupSet.id}
                 onChange={createGroupSetOnChange(groupSet.id, selectGroupSet)}
                 {...rest}
             />

--- a/src/components/SectionHeadline.js
+++ b/src/components/SectionHeadline.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import { getDocsUrl } from '../utils/getDocsUrl'
-import AppContext from '../pages/AppContext'
 import PageHelper from '../components/PageHelper'
 
 export const SectionHeadline = props => (
@@ -19,13 +18,7 @@ export const SectionHeadline = props => (
             </span>
         )}
         {props.label}
-        <AppContext.Consumer>
-            {({ d2 }) => (
-                <PageHelper
-                    url={getDocsUrl(d2.system.version, props.sectionKey)}
-                />
-            )}
-        </AppContext.Consumer>
+        <PageHelper url={getDocsUrl(props.sectionKey)} />
         <style jsx>{`
             .back-button {
                 cursor: pointer;

--- a/src/components/__tests__/AppRouter.test.js
+++ b/src/components/__tests__/AppRouter.test.js
@@ -3,14 +3,14 @@ import React from 'react'
 
 import { shallow } from 'enzyme'
 
-import { AppRouterComponent as AppRouter } from '../AppRouter'
+import AppRouter from '../AppRouter'
 import { sectionOrder } from '../../config/sections.config'
 
 jest.mock('@dhis2/d2-ui-org-unit-tree', () => ({ OrgUnitTree: 'OrgUnitTree' }))
 
 jest.mock('@dhis2/d2-ui-org-unit-tree', () => 'OrgUnitTree')
 
-const ownShallow = () => shallow(<AppRouter d2={{}} />)
+const ownShallow = () => shallow(<AppRouter />)
 
 it('AppRouter renders without crashing', () => {
     ownShallow()

--- a/src/components/__tests__/__snapshots__/OrganisationUnitGroupSets.test.js.snap
+++ b/src/components/__tests__/__snapshots__/OrganisationUnitGroupSets.test.js.snap
@@ -16,6 +16,7 @@ Array [
             ],
           }
     }
+    key="organisationUnitGroupSet1"
     onChange={[Function]}
     values={Object {}}
 />,
@@ -33,6 +34,7 @@ Array [
             ],
           }
     }
+    key="organisationUnitGroupSet2"
     onChange={[Function]}
     values={Object {}}
 />,

--- a/src/config/sections.config.js
+++ b/src/config/sections.config.js
@@ -4,10 +4,9 @@ export const STANDARD_REPORT_SECTION_KEY = 'standard-report'
 export const DATA_SET_REPORT_SECTION_KEY = 'data-set-report'
 export const REPORTING_RATE_SUMMARY_SECTION_KEY = 'reporting-rate-summary'
 export const RESOURCE_SECTION_KEY = 'resource'
-export const ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY =
+export const ORG_UNIT_DIST_REPORT_SECTION_KEY =
     'organisation-unit-distribution-report'
-export const ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_PATH =
-    '/organisation-unit-distribution-report'
+export const ORG_UNIT_DIST_REPORT_SECTION_PATH = `/${ORG_UNIT_DIST_REPORT_SECTION_KEY}`
 export const DATA_APPROVAL_SECTION_KEY = 'data-approval'
 
 export const sectionOrder = [
@@ -15,7 +14,7 @@ export const sectionOrder = [
     DATA_SET_REPORT_SECTION_KEY,
     REPORTING_RATE_SUMMARY_SECTION_KEY,
     RESOURCE_SECTION_KEY,
-    ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY,
+    ORG_UNIT_DIST_REPORT_SECTION_KEY,
 ]
 
 export const sections = {
@@ -71,9 +70,9 @@ export const sections = {
             docs: 'using_reporting_resources',
         },
     },
-    [ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY]: {
-        key: ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY,
-        path: `/${ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY}`,
+    [ORG_UNIT_DIST_REPORT_SECTION_KEY]: {
+        key: ORG_UNIT_DIST_REPORT_SECTION_KEY,
+        path: `/${ORG_UNIT_DIST_REPORT_SECTION_KEY}`,
         info: {
             label: i18n.t('Organisation Unit Distribution Report'),
             description: i18n.t(

--- a/src/config/sections.config.js
+++ b/src/config/sections.config.js
@@ -6,7 +6,6 @@ export const REPORTING_RATE_SUMMARY_SECTION_KEY = 'reporting-rate-summary'
 export const RESOURCE_SECTION_KEY = 'resource'
 export const ORG_UNIT_DIST_REPORT_SECTION_KEY =
     'organisation-unit-distribution-report'
-export const ORG_UNIT_DIST_REPORT_SECTION_PATH = `/${ORG_UNIT_DIST_REPORT_SECTION_KEY}`
 export const DATA_APPROVAL_SECTION_KEY = 'data-approval'
 
 export const sectionOrder = [

--- a/src/pages/AppContext.js
+++ b/src/pages/AppContext.js
@@ -1,6 +1,0 @@
-import React from 'react'
-
-export default React.createContext({
-    d2: null,
-    i18n: null,
-})

--- a/src/pages/OrganisationUnitDistributionReport.js
+++ b/src/pages/OrganisationUnitDistributionReport.js
@@ -4,7 +4,7 @@ import React from 'react'
 
 import { Form } from './organisation-unit-distribution-report/Form'
 import {
-    ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY,
+    ORG_UNIT_DIST_REPORT_SECTION_KEY,
     sections,
 } from '../config/sections.config'
 import { SectionHeadline } from '../components/SectionHeadline'
@@ -27,13 +27,9 @@ class OrganisationUnitDistributionReport extends React.Component {
             <div>
                 <SectionHeadline
                     label={
-                        sections[
-                            ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY
-                        ].info.label
+                        sections[ORG_UNIT_DIST_REPORT_SECTION_KEY].info.label
                     }
-                    sectionKey={
-                        ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_KEY
-                    }
+                    sectionKey={ORG_UNIT_DIST_REPORT_SECTION_KEY}
                 />
                 <Paper className={container.className}>
                     <Form

--- a/src/pages/Resource.js
+++ b/src/pages/Resource.js
@@ -24,10 +24,6 @@ class Resource extends React.Component {
         this.contextMenuOptions = createContextMenuOptions(props)
     }
 
-    getChildContext() {
-        return { d2: this.props.d2 }
-    }
-
     componentDidMount() {
         if (this.props.resources.length === 0) {
             this.props.loadResources()
@@ -61,7 +57,6 @@ class Resource extends React.Component {
                         goToPrevPage={this.props.goToPrevPage}
                     />
                     <ResourceActions
-                        d2={this.props.d2}
                         open={this.props.open}
                         selectedAction={this.props.selectedAction}
                         selectedResource={this.props.selectedResource}
@@ -78,7 +73,6 @@ class Resource extends React.Component {
 }
 
 Resource.propTypes = {
-    d2: PropTypes.object.isRequired,
     open: PropTypes.bool.isRequired,
     loadingResources: PropTypes.bool.isRequired,
     search: PropTypes.string.isRequired,
@@ -86,7 +80,6 @@ Resource.propTypes = {
     resources: PropTypes.array.isRequired,
     pager: PropTypes.object.isRequired,
     selectedResource: PropTypes.object.isRequired,
-
     goToNextPage: PropTypes.func.isRequired,
     goToPrevPage: PropTypes.func.isRequired,
     loadResources: PropTypes.func.isRequired,
@@ -98,10 +91,6 @@ Resource.propTypes = {
     editResource: PropTypes.func.isRequired,
     showSharingSettings: PropTypes.func.isRequired,
     closeContextMenu: PropTypes.func.isRequired,
-}
-
-Resource.childContextTypes = {
-    d2: PropTypes.object,
 }
 
 const ConnectedResource = connectResource(Resource)

--- a/src/pages/StandardReport.js
+++ b/src/pages/StandardReport.js
@@ -32,10 +32,6 @@ class StandardReport extends React.Component {
         this.contextMenuOptions = createContextMenuOptions(props)
     }
 
-    getChildContext() {
-        return { d2: this.props.d2 }
-    }
-
     componentDidMount() {
         if (this.props.reports.length === 0) {
             this.props.loadStandardReports(true)
@@ -71,7 +67,6 @@ class StandardReport extends React.Component {
                         goToPrevPage={this.props.goToPrevPage}
                     />
                     <StandardReportActions
-                        d2={this.props.d2}
                         open={this.props.open}
                         selectedAction={this.props.selectedAction}
                         selectedReport={this.props.selectedReport}
@@ -99,7 +94,6 @@ class StandardReport extends React.Component {
 }
 
 StandardReport.propTypes = {
-    d2: PropTypes.object.isRequired,
     loading: PropTypes.bool.isRequired,
     pager: PropTypes.object.isRequired,
     reports: PropTypes.array.isRequired,
@@ -124,10 +118,6 @@ StandardReport.propTypes = {
     updateStandardReport: PropTypes.func.isRequired,
     addStandardReport: PropTypes.func.isRequired,
     closeReport: PropTypes.func.isRequired,
-}
-
-StandardReport.childContextTypes = {
-    d2: PropTypes.object,
 }
 
 const ConnectedStandardReport = connectStandardReport(StandardReport)

--- a/src/pages/resource/ResourceActions.js
+++ b/src/pages/resource/ResourceActions.js
@@ -1,10 +1,10 @@
+import SharingDialog from '@dhis2/d2-ui-sharing-dialog'
 import PropTypes from 'prop-types'
 import React from 'react'
-import SharingDialog from '@dhis2/d2-ui-sharing-dialog'
-
+import { getD2 } from '../../utils/api'
+import { resourceActions } from '../../utils/resource/constants'
 import { ConnectedAddResource } from './AddResource'
 import { ConnectedEditResource } from './EditResource'
-import { resourceActions } from '../../utils/resource/constants'
 
 const ResourceActions = props => {
     const { selectedAction } = props
@@ -25,7 +25,7 @@ const ResourceActions = props => {
                 id={props.selectedResource.id}
                 type="document"
                 onRequestClose={props.handleClose}
-                d2={props.d2}
+                d2={getD2()}
             />
         )
     }
@@ -34,7 +34,6 @@ const ResourceActions = props => {
 }
 
 ResourceActions.propTypes = {
-    d2: PropTypes.object.isRequired,
     open: PropTypes.bool.isRequired,
     selectedAction: PropTypes.string.isRequired,
     selectedResource: PropTypes.object.isRequired,

--- a/src/pages/standard-report/StandardReportActions.js
+++ b/src/pages/standard-report/StandardReportActions.js
@@ -6,9 +6,9 @@ import {
     CONTEXT_MENU_ACTION,
 } from './standard.report.conf'
 import { ConnectedAddEditStdReport } from './AddEditStdReport'
+import { getD2 } from '../../utils/api'
 
 const StandardReportActions = ({
-    d2,
     open,
     selectedAction,
     selectedReport,
@@ -21,7 +21,7 @@ const StandardReportActions = ({
         return (
             <SharingDialog
                 id={selectedReport.id}
-                d2={d2}
+                d2={getD2()}
                 open={open}
                 type="report"
                 onRequestClose={handleClose}
@@ -32,7 +32,6 @@ const StandardReportActions = ({
     if (selectedAction === CONTEXT_MENU_ACTION.EDIT) {
         return (
             <ConnectedAddEditStdReport
-                d2={d2}
                 open={open}
                 edit={true}
                 onSubmit={updateStandardReport}
@@ -45,7 +44,6 @@ const StandardReportActions = ({
     if (selectedAction === ADD_NEW_REPORT_ACTION) {
         return (
             <ConnectedAddEditStdReport
-                d2={d2}
                 open={open}
                 edit={false}
                 onSubmit={addStandardReport}
@@ -59,7 +57,6 @@ const StandardReportActions = ({
 }
 
 StandardReportActions.propTypes = {
-    d2: PropTypes.object.isRequired,
     open: PropTypes.bool.isRequired,
     selectedAction: PropTypes.string.isRequired,
     selectedReport: PropTypes.object.isRequired,

--- a/src/redux/selectors/getIsUiBlocked.js
+++ b/src/redux/selectors/getIsUiBlocked.js
@@ -1,4 +1,4 @@
-import { ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_PATH } from '../../config/sections.config'
+import { ORG_UNIT_DIST_REPORT_SECTION_PATH } from '../../config/sections.config'
 
 export const getIsUiBlocked = state =>
     state.organisationUnits.loading ||
@@ -7,5 +7,4 @@ export const getIsUiBlocked = state =>
     (atOrgUnitDistReportSection(state) && state.orgUnitGroupSets.loading)
 
 const atOrgUnitDistReportSection = ({ router }) =>
-    router.location.pathname ===
-    ORGANISATION_UNIT_DISTRIBUTION_REPORT_SECTION_PATH
+    router.location.pathname === ORG_UNIT_DIST_REPORT_SECTION_PATH

--- a/src/redux/selectors/getIsUiBlocked.js
+++ b/src/redux/selectors/getIsUiBlocked.js
@@ -1,4 +1,7 @@
-import { ORG_UNIT_DIST_REPORT_SECTION_PATH } from '../../config/sections.config'
+import {
+    sections,
+    ORG_UNIT_DIST_REPORT_SECTION_KEY,
+} from '../../config/sections.config'
 
 export const getIsUiBlocked = state =>
     state.organisationUnits.loading ||
@@ -7,4 +10,4 @@ export const getIsUiBlocked = state =>
     (atOrgUnitDistReportSection(state) && state.orgUnitGroupSets.loading)
 
 const atOrgUnitDistReportSection = ({ router }) =>
-    router.location.pathname === ORG_UNIT_DIST_REPORT_SECTION_PATH
+    router.location.pathname === sections[ORG_UNIT_DIST_REPORT_SECTION_KEY].path

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -57,6 +57,18 @@ export const getApi = () => api
 export const getContextPath = () => d2.system.systemInfo.contextPath
 
 /**
+ * @typedef {Object} Version
+ * @property {number} major The major version
+ * @property {number} minor The minor version
+ * @property {boolean} snapshot Flag to indicate if build is a snapshot
+ */
+
+/**
+ * @returns {Version} The dhis2-core instance version
+ */
+export const getSystemVersion = () => d2.system.version
+
+/**
  * @return {Promise} Period types
  */
 export const getPeriodTypes = () =>

--- a/src/utils/getDocsUrl.js
+++ b/src/utils/getDocsUrl.js
@@ -1,4 +1,5 @@
 import { sections } from '../config/sections.config'
+import { getSystemVersion } from './api'
 
 export const DOCS_LINK = 'https://ci.dhis2.org/docs'
 export const DEFAULT_DOC_LANGUAGE = 'en'
@@ -12,18 +13,18 @@ export const DEFAULT_DOC_LANGUAGE = 'en'
  *
  * @returns {string} `master` for a snapshot branch. `25` for 2.25 etc.
  */
-const getDocsVersion = ({ major, minor, snapshot }) => {
+const getDocsVersion = () => {
+    console.log(getSystemVersion())
+    const { major, minor, snapshot } = getSystemVersion()
     if (snapshot) {
         return 'master'
     }
     return `${major}.${minor}`
 }
 
-export const getDocsUrl = (systemVersion, sectionKey, lng) => {
-    const docLng = lng || DEFAULT_DOC_LANGUAGE
-    return `${DOCS_LINK}/${getDocsVersion(systemVersion)}/${docLng}/user/html/${
-        sections[sectionKey].info.docs
-    }.html`
+export const getDocsUrl = (sectionKey, lng = DEFAULT_DOC_LANGUAGE) => {
+    const baseUrl = `${DOCS_LINK}/${getDocsVersion()}/${lng}/user/html/`
+    return `${baseUrl}${sections[sectionKey].info.docs}.html`
 }
 
 export default getDocsUrl

--- a/src/utils/getDocsUrl.js
+++ b/src/utils/getDocsUrl.js
@@ -14,7 +14,6 @@ export const DEFAULT_DOC_LANGUAGE = 'en'
  * @returns {string} `master` for a snapshot branch. `25` for 2.25 etc.
  */
 const getDocsVersion = () => {
-    console.log(getSystemVersion())
     const { major, minor, snapshot } = getSystemVersion()
     if (snapshot) {
         return 'master'


### PR DESCRIPTION
I've managed to remove the `AppContext` stuff completely. Now using a combination between the legacy Context API (which is required by the older d2-ui components), and the `getD2` helper. Managed to remove quite a lot of stuff.