### PR TITLE
fix(resource): disable submit button if form is invalid

### DIFF
--- a/src/components/form/Button.js
+++ b/src/components/form/Button.js
@@ -9,6 +9,7 @@ export const Button = props => (
             type={props.type}
             onClick={props.onClick}
             color={props.isPrimary ? 'primary' : 'default'}
+            disabled={props.disabled}
         >
             {props.label}
         </D2UIButton>
@@ -27,6 +28,7 @@ Button.propTypes = {
     onClick: PropTypes.func.isRequired,
     isPrimary: PropTypes.bool,
     type: PropTypes.string,
+    disabled: PropTypes.bool,
 }
 
 Button.defaultProps = {

--- a/src/pages/resource/add-edit-resource/ResourceForm.js
+++ b/src/pages/resource/add-edit-resource/ResourceForm.js
@@ -18,7 +18,7 @@ import { Url } from './ResourceForm/Url'
 export const ResourceForm = props => (
     <FormDialog title={props.title} open={props.open} onClose={props.onCancel}>
         <Form onSubmit={props.onSubmit} initialValues={props.initialValues}>
-            {({ handleSubmit, values }) => (
+            {({ handleSubmit, values, valid }) => (
                 <form onSubmit={handleSubmit}>
                     <DialogContent>
                         <FormSection>
@@ -52,6 +52,7 @@ export const ResourceForm = props => (
                         onSubmitLabel={props.onSubmitLabel}
                         onSubmit={handleSubmit}
                         onCancel={props.onCancel}
+                        submitDisabled={!valid}
                     />
                 </form>
             )}

--- a/src/pages/resource/add-edit-resource/ResourceForm/Actions.js
+++ b/src/pages/resource/add-edit-resource/ResourceForm/Actions.js
@@ -10,6 +10,7 @@ export const Actions = props => (
             label={props.onSubmitLabel}
             isPrimary={true}
             onClick={props.onSubmit}
+            disabled={props.submitDisabled}
         />
 
         <Button label={props.onCancelLabel} onClick={props.onCancel} />
@@ -21,6 +22,7 @@ Actions.propTypes = {
     onCancelLabel: PropTypes.string.isRequired,
     onSubmit: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
+    submitDisabled: PropTypes.bool.isRequired,
 }
 
 Actions.defaultProps = {


### PR DESCRIPTION
This PR ensures that the save button is disabled when the resource form has invalid values