### PR TITLE
DHIS2-6525: download default report templates via webapi

### DIFF
--- a/src/pages/standard-report/AddEditStdReport.js
+++ b/src/pages/standard-report/AddEditStdReport.js
@@ -98,7 +98,7 @@ export const Component = props => (
                                 <div className="col-xs-6">
                                     <FormHelperText />
                                     <DesignFileDownloadButton
-                                        isEditing={!!props.selectedReport}
+                                        isEditing={props.edit}
                                         reportType={values.type}
                                         reportId={
                                             props.edit

--- a/src/pages/standard-report/add-edit-report/DesignFileDownloadButton.js
+++ b/src/pages/standard-report/add-edit-report/DesignFileDownloadButton.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import FormHelperText from '@material-ui/core/FormHelperText'
 import Button from '@material-ui/core/Button'
 import i18n from '@dhis2/d2-i18n'
-import { getApi, getContextPath } from '../../../utils/api'
+import { getApi } from '../../../utils/api'
 import {
     reportTypes,
     REPORTS_ENDPOINT,
@@ -18,8 +18,7 @@ export const DesignFileDownloadButton = ({
     let url
     let label
     const api = getApi()
-    const contextPath = getContextPath()
-    const type = reportType === reportTypes.HTML ? 'html' : 'jasper'
+    const type = reportType === reportTypes.HTML ? 'html' : 'xml'
 
     if (isEditing) {
         label = i18n.t('Get current design')
@@ -29,7 +28,7 @@ export const DesignFileDownloadButton = ({
             reportType === reportTypes.HTML
                 ? i18n.t('Get HTML Report Template')
                 : i18n.t('Get Jasper Report Template')
-        url = `${contextPath}/${REPORT_TEMPLATES_ENDPOINT}?type=${type}`
+        url = `${api.baseUrl}/${REPORT_TEMPLATES_ENDPOINT}.${type}`
     }
 
     return (

--- a/src/pages/standard-report/standard.report.conf.js
+++ b/src/pages/standard-report/standard.report.conf.js
@@ -2,8 +2,7 @@ import i18n from '@dhis2/d2-i18n'
 
 export const REPORTS_ENDPOINT = 'reports'
 export const REPORT_TABLES_ENDPOINT = 'reportTables'
-export const REPORT_TEMPLATES_ENDPOINT =
-    'dhis-web-reporting/getReportTemplate.action'
+export const REPORT_TEMPLATES_ENDPOINT = 'reportTemplate'
 export const ADD_NEW_REPORT_ACTION = 'ADD_NEW_REPORT_ACTION'
 
 export const CONTEXT_MENU_ACTION = {


### PR DESCRIPTION
We used to call an old .action endpoint to get the default report templates, but Lars now introduced proper api endpoints for this.

Note:
The change in `AddEditStdReport` is an related bug-fix, which caused the `DesignFileDownloadButton` to always be in edit-mode