### PR TITLE
feat(reports): render report content and loader in a separate Paper div

### DIFF
--- a/src/components/ReportLoader.js
+++ b/src/components/ReportLoader.js
@@ -2,28 +2,30 @@ import { CircularProgress } from '@dhis2/d2-ui-core'
 import isEmpty from 'lodash.isempty'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { container } from '../utils/styles/shared.js'
 import { reportContent } from '../utils/react/propTypes'
+import Paper from '@material-ui/core/Paper'
 
 const ReportLoader = ({ isLoading, content, children }) => {
-    if (isLoading) {
-        return (
-            <div className="report-loader">
-                <CircularProgress />
-                <style jsx>{`
-                    div {
-                        margin: 48px 0;
-                        text-align: center;
-                    }
-                `}</style>
-            </div>
-        )
-    }
-
-    if (isEmpty(content)) {
+    if (!isLoading && isEmpty(content)) {
         return null
     }
 
-    return children
+    const childrenToWrap = isLoading ? (
+        <div className="report-loader">
+            <CircularProgress />
+            <style jsx>{`
+                div {
+                    margin: 48px 0;
+                    text-align: center;
+                }
+            `}</style>
+        </div>
+    ) : (
+        children
+    )
+
+    return <Paper className={container.className}>{childrenToWrap}</Paper>
 }
 
 ReportLoader.propTypes = {

--- a/src/components/SectionHeadline.js
+++ b/src/components/SectionHeadline.js
@@ -20,7 +20,10 @@ export const SectionHeadline = props => (
         {props.label}
         <PageHelper url={getDocsUrl(props.sectionKey)} />
         <style jsx>{`
-            .back-button {
+            h1 {
+                margin-bottom: 0;
+            }
+            h1.back-button {
                 cursor: pointer;
                 outline: none;
             }

--- a/src/components/__tests__/__snapshots__/ReportLoader.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ReportLoader.test.js.snap
@@ -1,23 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ReportLoader/> Renders a loader when isLoading is true 1`] = `
-<div
-  className="report-loader"
->
-  <CircularProgress
-    large={false}
-    small={false}
-    style={Object {}}
-  />
-  <style>
-    
-                        div {
-                            margin: 48px 0;
-                            text-align: center;
-                        }
-                    
-  </style>
-</div>
+<WithStyles(Paper)>
+  <div
+    className="report-loader"
+  >
+    <CircularProgress
+      large={false}
+      small={false}
+      style={Object {}}
+    />
+    <style>
+      
+                      div {
+                          margin: 48px 0;
+                          text-align: center;
+                      }
+                  
+    </style>
+  </div>
+</WithStyles(Paper)>
 `;
 
-exports[`<ReportLoader/> Renders its children when isLoading is false and content is non-empty 1`] = `"<div>Hello world</div>"`;
+exports[`<ReportLoader/> Renders its children when isLoading is false and content is non-empty 1`] = `"<div class=\\"MuiPaper-root-1 MuiPaper-elevation2-5 MuiPaper-rounded-2\\"><div>Hello world</div></div>"`;

--- a/src/pages/DataSetReport.js
+++ b/src/pages/DataSetReport.js
@@ -30,17 +30,17 @@ const DataSetReport = props => (
                     isGetReportDisabled={!props.isActionEnabled}
                 />
             </div>
-            <DataSetReportOutput
-                isHtmlReport={props.isHtmlReport}
-                content={props.reportContent}
-                isLoading={props.isReportLoading}
-                fileUrls={props.fileUrls}
-                reportComment={props.reportComment}
-                shareDataSetReportComment={props.shareDataSetReportComment}
-                setDataSetReportComment={props.setDataSetReportComment}
-            />
-            {container.styles}
         </Paper>
+        <DataSetReportOutput
+            isHtmlReport={props.isHtmlReport}
+            content={props.reportContent}
+            isLoading={props.isReportLoading}
+            fileUrls={props.fileUrls}
+            reportComment={props.reportComment}
+            shareDataSetReportComment={props.shareDataSetReportComment}
+            setDataSetReportComment={props.setDataSetReportComment}
+        />
+        {container.styles}
         <Snackbar />
     </div>
 )

--- a/src/pages/OrganisationUnitDistributionReport.js
+++ b/src/pages/OrganisationUnitDistributionReport.js
@@ -37,22 +37,22 @@ class OrganisationUnitDistributionReport extends React.Component {
                         onGetReportClick={this.props.loadTable}
                         onGetChartClick={this.props.loadChart}
                     />
-                    <div id="report-container">
-                        {!this.props.shouldShowChart && (
-                            <TabularReport
-                                content={this.props.reportContent}
-                                isLoading={this.props.loading}
-                                fileUrls={this.props.fileUrls}
-                            />
-                        )}
-                        {this.props.shouldShowChart && (
-                            <BarChart
-                                content={this.props.reportContent}
-                                isLoading={this.props.loading}
-                            />
-                        )}
-                    </div>
                 </Paper>
+                <div id="report-container">
+                    {!this.props.shouldShowChart && (
+                        <TabularReport
+                            content={this.props.reportContent}
+                            isLoading={this.props.loading}
+                            fileUrls={this.props.fileUrls}
+                        />
+                    )}
+                    {this.props.shouldShowChart && (
+                        <BarChart
+                            content={this.props.reportContent}
+                            isLoading={this.props.loading}
+                        />
+                    )}
+                </div>
                 <Snackbar />
                 {container.styles}
             </div>

--- a/src/pages/ReportingRateSummary.js
+++ b/src/pages/ReportingRateSummary.js
@@ -25,12 +25,12 @@ const ReportingRateSummary = props => (
                 loadReportData={props.loadReportData}
                 isActionEnabled={props.isActionEnabled}
             />
-            <TabularReport
-                content={props.reportContent}
-                isLoading={props.isReportLoading}
-                fileUrls={props.fileUrls}
-            />
         </Paper>
+        <TabularReport
+            content={props.reportContent}
+            isLoading={props.isReportLoading}
+            fileUrls={props.fileUrls}
+        />
         <Snackbar />
         {container.styles}
     </div>

--- a/src/utils/styles/shared.js
+++ b/src/utils/styles/shared.js
@@ -10,6 +10,7 @@ export const formLabel = resolve`
 `
 export const container = resolve`
     padding: 16px;
+    margin-top: 16px;
 `
 
 export const card = resolve`


### PR DESCRIPTION
The report content and the loader now renders a separate Paper dev. I've also updated the relevant snapshots.