### PR TITLE
fix(available-org-unit-tree): set max-height of 400px

### DIFF
--- a/src/components/AvailableOrganisationUnitsTree.js
+++ b/src/components/AvailableOrganisationUnitsTree.js
@@ -32,6 +32,7 @@ export function AvailableOrganisationUnitsTree({
                     box-sizing: border-box;
                     font-weight: 300;
                     max-height: 400px;
+                    padding: 10px 5px;
                 }
             `}</style>
         </div>

--- a/src/components/AvailableOrganisationUnitsTree.js
+++ b/src/components/AvailableOrganisationUnitsTree.js
@@ -31,6 +31,7 @@ export function AvailableOrganisationUnitsTree({
                     width: 100%;
                     box-sizing: border-box;
                     font-weight: 300;
+                    max-height: 400px;
                 }
             `}</style>
         </div>

--- a/src/components/__tests__/__snapshots__/AvailableOrganisationUnitsTree.test.js.snap
+++ b/src/components/__tests__/__snapshots__/AvailableOrganisationUnitsTree.test.js.snap
@@ -19,6 +19,7 @@ exports[`Test <AvailableOrganisationUnitsTree /> rendering: Should render OrgUni
                         width: 100%;
                         box-sizing: border-box;
                         font-weight: 300;
+                        max-height: 400px;
                     }
                 
   </style>

--- a/src/components/__tests__/__snapshots__/AvailableOrganisationUnitsTree.test.js.snap
+++ b/src/components/__tests__/__snapshots__/AvailableOrganisationUnitsTree.test.js.snap
@@ -20,6 +20,7 @@ exports[`Test <AvailableOrganisationUnitsTree /> rendering: Should render OrgUni
                         box-sizing: border-box;
                         font-weight: 300;
                         max-height: 400px;
+                        padding: 10px 5px;
                     }
                 
   </style>


### PR DESCRIPTION
400px seems a good size: you can still see all un-expanded leaves of the base-node and once you start expanding a lot, a scroll bar will appear.