### PR TITLE
fix(standard-reports): unset boolean values correctly

### DIFF
--- a/src/redux/actions/standardReport.js
+++ b/src/redux/actions/standardReport.js
@@ -25,6 +25,7 @@ import {
     getReportParams,
     isHtmlReport,
     validateRequiredParams,
+    processCheckboxValues,
 } from '../../utils/standardReport'
 import {
     clearFeedback,
@@ -378,18 +379,22 @@ export const loadingSendStandardReportError = () => ({
  * @param {bool} isEdit - When false, add new report
  * @returns {Promise}
  */
-export const sendStandardReport = (report, isEdit) => dispatch => {
+export const sendStandardReport = (report, isEdit) => (dispatch, getState) => {
     dispatch(loadingSendStandardReportStart())
+
+    const {
+        standardReport: { selectedReport },
+    } = getState()
 
     const formattedReport = {
         ...report,
-        relativePeriods: (report.relativePeriods || []).reduce(
-            (acc, cur) => ({ ...acc, [cur]: true }),
-            {}
+        relativePeriods: processCheckboxValues(
+            report.relativePeriods,
+            selectedReport.relativePeriods
         ),
-        reportParams: (report.reportParams || []).reduce(
-            (acc, cur) => ({ ...acc, [cur]: true }),
-            {}
+        reportParams: processCheckboxValues(
+            report.reportParams,
+            selectedReport.reportParams
         ),
         reportTable: report.reportTable ? { id: report.reportTable } : '',
     }

--- a/src/utils/standardReport/index.js
+++ b/src/utils/standardReport/index.js
@@ -59,3 +59,11 @@ export const validateRequiredParams = (state, requiredParams) => {
 
     return errors
 }
+
+export const processCheckboxValues = (formSelectedKeys, stateValues) => {
+    const selectedKeys = new Set(formSelectedKeys)
+    return Object.keys(stateValues).reduce((acc, key) => {
+        acc[key] = selectedKeys.has(key)
+        return acc
+    }, {})
+}

--- a/src/utils/standardReport/index.js
+++ b/src/utils/standardReport/index.js
@@ -62,14 +62,8 @@ export const validateRequiredParams = (state, requiredParams) => {
 
 export const processCheckboxValues = (formSelectedKeys, stateValues) => {
     const selectedKeys = new Set(formSelectedKeys)
-
     return Object.keys(stateValues).reduce((acc, key) => {
-        const formValue = selectedKeys.has(key)
-        const stateValue = stateValues[key]
-
-        if (formValue !== stateValue) {
-            acc[key] = formValue
-        }
+        acc[key] = selectedKeys.has(key)
         return acc
     }, {})
 }

--- a/src/utils/standardReport/index.js
+++ b/src/utils/standardReport/index.js
@@ -62,8 +62,14 @@ export const validateRequiredParams = (state, requiredParams) => {
 
 export const processCheckboxValues = (formSelectedKeys, stateValues) => {
     const selectedKeys = new Set(formSelectedKeys)
+
     return Object.keys(stateValues).reduce((acc, key) => {
-        acc[key] = selectedKeys.has(key)
+        const formValue = selectedKeys.has(key)
+        const stateValue = stateValues[key]
+
+        if (formValue !== stateValue) {
+            acc[key] = formValue
+        }
         return acc
     }, {})
 }


### PR DESCRIPTION
### The problem
We were sending an object of values that were selected, but this doesn't trigger deselection of the other values on the server.

### The solution
We are now iterating over all boolean properties that are present in the state and determining for each property if its state-value is different from the form-value. If so, we include it in the payload object. This way values can be set and unset.