### PR TITLE
fix(standard-reports): remove download attribute to avoid chrome issue

### DIFF
--- a/src/pages/standard-report/add-edit-report/DesignFileDownloadButton.js
+++ b/src/pages/standard-report/add-edit-report/DesignFileDownloadButton.js
@@ -36,7 +36,7 @@ export const DesignFileDownloadButton = ({
             <FormHelperText>{label}</FormHelperText>
             <FormHelperText>
                 <Button variant="contained" component="span">
-                    <a href={url} target="_blank" download>
+                    <a href={url} target="_blank" download={type !== 'html'}>
                         Download
                     </a>
                 </Button>

--- a/src/pages/standard-report/add-edit-report/DesignFileDownloadButton.js
+++ b/src/pages/standard-report/add-edit-report/DesignFileDownloadButton.js
@@ -36,6 +36,11 @@ export const DesignFileDownloadButton = ({
             <FormHelperText>{label}</FormHelperText>
             <FormHelperText>
                 <Button variant="contained" component="span">
+                    {/* 
+                    Having an anchor to a HTML file with a download attribute 
+                    causes unexpected behavior in Chrome, see:
+                    https://dhis2.slack.com/archives/G451J9KGR/p1570090946063500
+                    */}
                     <a href={url} target="_blank" download={type !== 'html'}>
                         Download
                     </a>


### PR DESCRIPTION
The links to the XML files will still have the download attribute, but for HTML files I'm omitting it.