### PR TITLE
fix: downgrade api version to v32 for dhis2-core v32

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
       "name": "DHIS2"
     },
     "dhis2": {
-      "apiVersion": "33"
+      "apiVersion": "32"
     },
     "activities": {
       "dhis": {


### PR DESCRIPTION
This is the hardcoded fix we discussed. I've tested locally against a v32 instance and that was working just fine.