### PR TITLE
fix: switch to unversioned api calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,7 @@ getManifest('manifest.webapp').then(manifest => {
             ? manifest.getBaseUrl()
             : process.env.REACT_APP_DHIS2_BASE_URL
 
-    const apiVersion = manifest.dhis2.apiVersion
-    const apiUrl = `${baseUrl}/api/${apiVersion}`
+    const apiUrl = `${baseUrl}/api`
 
     // init d2 with configs
     init({
@@ -52,7 +51,7 @@ getManifest('manifest.webapp').then(manifest => {
                 <RuntimeProvider
                     config={{
                         baseUrl,
-                        apiVersion,
+                        apiVersion: '',
                     }}
                 >
                     <Provider store={store}>


### PR DESCRIPTION
This is the switch to unversioned calls we discussed.

I was considering cleaning things up q bit more by removing the manifest from `package.json` and reading the `baseUrl` differently. But then I thought it might be better to do that when we uneject this app. And we won't be unejecting until we've swapped our styled-jsx stuff with CSS Modules. So in the end, I only implemented unversioned api calls.