### PR TITLE
fix: response-rate-summary requests

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -12,7 +12,6 @@ import {
     getFileUrls,
     postDataSetReportCommentUrl,
     getDataSetReportFileUrls,
-    sanitizeApiUrl,
 } from './api/helpers'
 import { isCustomFormType } from './dataSetReport/isCustomFormType'
 
@@ -201,7 +200,7 @@ export const getReportingRateSummaryReport = async (
     // which only spawns a single request
     const extensions = ['json', 'xls', 'csv']
     const [{ url }, ...fileUrls] = getAnalyticsFileUrls(req, extensions)
-    return api.get(sanitizeApiUrl(url)).then(data => ({ ...data, fileUrls }))
+    return api.get(url).then(data => ({ ...data, fileUrls }))
 }
 
 /**

--- a/src/utils/api/helpers.js
+++ b/src/utils/api/helpers.js
@@ -87,13 +87,6 @@ export const getAnalyticsFileUrls = (req, extensions) => {
     }, [])
 }
 
-export const sanitizeApiUrl = url => {
-    // Because dev envs use an absolute path, but deployed instances a relative one
-    // And because `d2.get` will prepend "/api" for relative paths, we need to remove
-    // "api/" from the string for relative paths
-    return url.includes('../api') ? url.replace('../api', '..') : url
-}
-
 export const getDataSetReportFileUrls = (resourceUrl, options) => {
     const mergedFilters = {
         ...options.dataSetDimensions,


### PR DESCRIPTION
Previously, when we were doing versioned API calls, when we called the `d2` Api `get` method with an url like this `../api/32/etc` it would actually do a GET request to `../api/api/32/etc`. We fixed this in https://github.com/dhis2/reports-app/commit/f315b8cd01ece66d5c9d8062c5b2a0602bcd205f by introducing the `sanitizeApiUrl` function (hack).

But it turns out that this behaviour doesn't happen when doing unversioned calls, so we can now remove the `sanitizeApiUrl` hack.
