### PR TITLE
fix(standard-report): prevent error when stateValues are undefined 34.0

### DIFF
--- a/src/utils/standardReport/index.js
+++ b/src/utils/standardReport/index.js
@@ -61,6 +61,10 @@ export const validateRequiredParams = (state, requiredParams) => {
 }
 
 export const processCheckboxValues = (formSelectedKeys, stateValues) => {
+    if (!stateValues) {
+        return {}
+    }
+
     const selectedKeys = new Set(formSelectedKeys)
     return Object.keys(stateValues).reduce((acc, key) => {
         acc[key] = selectedKeys.has(key)


### PR DESCRIPTION
This is to go into the 2.34.0 release