### PR TITLE
fix: import ./locales before anything else so i18 has the correct locale

### DIFF
--- a/src/AppWrapper.js
+++ b/src/AppWrapper.js
@@ -1,5 +1,6 @@
 import 'material-design-icons-iconfont/dist/material-design-icons.css'
 import 'flexboxgrid/css/flexboxgrid.css'
+import './locales'
 
 import React from 'react'
 import { Provider } from 'react-redux'
@@ -18,7 +19,6 @@ import { initApi } from './utils/api'
 import history from './utils/history'
 import injectTranslationsToD2 from './utils/injectTranslationsToD2'
 import store from './redux/store'
-import './locales'
 
 import App from './App'
 

--- a/src/utils/injectTranslationsToD2.js
+++ b/src/utils/injectTranslationsToD2.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../locales'
 
 const d2UiTranslations = {
     settings: i18n.t('Settings'),


### PR DESCRIPTION
I was importing `injectTranslationsToD2` before I was importing `./locales`. The result was that the resources for the user-locale hadn't been added yet when this `injectTranslationsToD2` was imported and it's calls to `i18n.t` were happening.

So moving the import to `./locales` fixed this.