### PR TITLE
fix(reporting-rate-summary): prevent `../api/api/<version>` urls

### DIFF
--- a/src/AppWrapper.js
+++ b/src/AppWrapper.js
@@ -11,6 +11,7 @@ import {
     createMuiTheme as createMui3Theme,
 } from '@material-ui/core/styles'
 
+import { useConfig } from '@dhis2/app-runtime'
 import { useD2 } from '@dhis2/app-runtime-adapter-d2'
 import { mui3theme } from '@dhis2/d2-ui-core'
 import D2UIApp from '@dhis2/d2-ui-app'
@@ -25,8 +26,10 @@ import App from './App'
 const MUI3Theme = createMui3Theme(mui3theme)
 
 const AppWrapper = () => {
+    const { baseUrl } = useConfig()
     const { d2 } = useD2({
         d2Config: {
+            baseUrl: baseUrl + '/api',
             schemas: [
                 'dataApprovalLevel',
                 'dataSet',


### PR DESCRIPTION
Quite likely a regression due to upgrading `d2` or switching to the `useD2` helper. The problem was that once deployed, the `get` method on the `d2` `API` class was being supplied with a relative url (starting with `../`) that also included `/api`, i.e. `../api/`. In `d2` the relative urls get prefixed with the `baseUrl`, which was also set to `../api`. The result is a GET request to `api/api`.

I've tested this fix both for development-mode, where the `baseUrl` is an absolute url like `localhost:8080/api`, and also for deployed apps, where the `baseUrl` is a relative url, i.e. `../api`, and didn't find any issues.