### PR TITLE
fix: let d2 make un-versioned api calls so urls don't break - v35 patch

### DIFF
--- a/src/AppWrapper.js
+++ b/src/AppWrapper.js
@@ -11,6 +11,7 @@ import {
     createMuiTheme as createMui3Theme,
 } from '@material-ui/core/styles'
 
+import { useConfig } from '@dhis2/app-runtime'
 import { useD2 } from '@dhis2/app-runtime-adapter-d2'
 import { mui3theme } from '@dhis2/d2-ui-core'
 import D2UIApp from '@dhis2/d2-ui-app'
@@ -25,8 +26,10 @@ import App from './App'
 const MUI3Theme = createMui3Theme(mui3theme)
 
 const AppWrapper = () => {
+    const { baseUrl } = useConfig()
     const { d2 } = useD2({
         d2Config: {
+            baseUrl: baseUrl + '/api',
             schemas: [
                 'dataApprovalLevel',
                 'dataSet',


### PR DESCRIPTION
This is simply a backport of https://github.com/dhis2/reports-app/pull/165