### PR TITLE
fix(html-report): inject page styles into iframe

### DIFF
--- a/src/pages/data-set-report/DataSetReportOutput.js
+++ b/src/pages/data-set-report/DataSetReportOutput.js
@@ -25,17 +25,6 @@ const DataSetReportOutput = props => (
                 ))
             )}
         </div>
-        <style jsx>{`
-            .dataset-html-report :global(table) {
-                margin-top: 16px;
-                border-collapse: collapse;
-            }
-            .dataset-html-report :global(table) :global(td),
-            .dataset-html-report :global(table) :global(th) {
-                border: 1px solid #bcbcbc;
-                padding: 4px;
-            }
-        `}</style>
     </ReportLoader>
 )
 

--- a/src/pages/standard-report/HtmlReport.js
+++ b/src/pages/standard-report/HtmlReport.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { getContextPath } from '../../utils/api'
 import CircularProgress from '@material-ui/core/CircularProgress'
-import { CSS_FILES, SCRIPT_FILES } from './HtmlReportAssets'
+import { CSS_FILES, SCRIPT_FILES, PAGE_STYLES } from './HtmlReportAssets'
 
 const wrapHtmlInTemplate = html => `
     <!DOCTYPE html>
@@ -11,6 +11,9 @@ const wrapHtmlInTemplate = html => `
             <meta charset="utf-8">
             ${CSS_FILES.map(createLinkTag).join('\n')}
             ${SCRIPT_FILES.map(createScriptTag).join('\n')}
+            <style type="text/css">
+                ${PAGE_STYLES}
+            </style>
         </head>
         <body>
             ${html}
@@ -81,7 +84,7 @@ class HtmlReport extends Component {
                 width="100%"
                 height={this.state.height}
                 seamless={true}
-                sandbox="allow-same-origin allow-scripts allow-modals"
+                sandbox="allow-same-origin allow-scripts allow-modals allow-downloads"
                 onLoad={this.onIframeLoad}
             >
                 <style jsx>{`

--- a/src/pages/standard-report/HtmlReportAssets.js
+++ b/src/pages/standard-report/HtmlReportAssets.js
@@ -27,3 +27,23 @@ export const SCRIPT_FILES = [
     '/dhis-web-commons/javascripts/date.js',
     '/dhis-web-commons/oust/oust.js',
 ]
+
+export const PAGE_STYLES = `
+    html {
+        line-height: 1.15;
+        text-size-adjust: 100%;
+    }
+    body {
+        font-family: Roboto, sans-serif;
+        box-sizing: inherit;
+    }
+    table {
+        margin-top: 16px;
+        border-collapse: collapse;
+    }
+    table td,
+    table th {
+        border: 1px solid #bcbcbc;
+        padding: 4px;
+    }
+`


### PR DESCRIPTION
We used to inject HTML into a div and applied some styles to its content. Now we are injecting the HTML into an iframe and these styles were gone. In this PR I've started injecting equivalent CSS into the iframe (and I removed the old styled-jsx styles because that was basically stale code).

Also, I added a small fix for #136. This is very unobtrusive, I only attached an extra sandbox attribute to the iframe.