### PR TITLE
fix(report-params): only use report.reportTable.reportParams if present

### DIFF
--- a/src/utils/standardReport/index.js
+++ b/src/utils/standardReport/index.js
@@ -22,9 +22,8 @@ export const isJasperReportTableReport = report =>
     report.type === reportTypes.JASPER_REPORT_TABLE
 
 export const getReportParams = report =>
-    isJasperReportTableReport(report)
-        ? report.reportTable.reportParams
-        : report.reportParams
+    (report.reportTable && report.reportTable.reportParams) ||
+    report.reportParams
 
 export const appendOrgUnitsAndReportPeriodToQueryString = (
     state,


### PR DESCRIPTION
This is more like the code we had in 2.34.1, which wasn't looking at the report-type to determine which reportParams to use. Apparently where we need to look for report-params isn't tied as closely to the report-type as I was assuming.