### PR TITLE
fix: clear selected dimension if selection is null [DHIS2-15041]

### DIFF
--- a/src/redux/reducers/dataSetDimensions.js
+++ b/src/redux/reducers/dataSetDimensions.js
@@ -1,6 +1,12 @@
 import { LOCATION_CHANGE } from 'connected-react-router'
 import { actionTypes } from '../actions/dataSetDimensions.js'
 
+const removeKeyFromObj = (obj, removeKey) => {
+    // eslint-disable-next-line no-unused-vars
+    const { [removeKey]: remove, ...remainingKeys } = obj
+    return remainingKeys
+}
+
 export const defaultState = {
     loading: false,
     options: [],
@@ -33,13 +39,21 @@ export const dataSetDimensions = (
             }
 
         case actionTypes.SELECT_DIMENSION_OPTION:
-            return {
-                ...state,
-                selected: {
-                    ...state.selected,
-                    [payload.dimension]: payload.value,
-                },
-            }
+            return payload.value
+                ? {
+                      ...state,
+                      selected: {
+                          ...state.selected,
+                          [payload.dimension]: payload.value,
+                      },
+                  }
+                : {
+                      ...state,
+                      selected: removeKeyFromObj(
+                          state.selected,
+                          payload.dimension
+                      ),
+                  }
 
         case LOCATION_CHANGE:
             return {


### PR DESCRIPTION
See [DHIS2-15041](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-15041)

Updates api request to not includes filters that have been selected and then cleared

[DHIS2-15041]: https://dhis2.atlassian.net/browse/DHIS2-15041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ