### PR TITLE
fix: use data view organisation units [DHIS-15651]

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -96,9 +96,11 @@ export const getOrganisationUnits = async () => {
         'children::isNotEmpty',
         'memberCount',
     ].join(',')
-    const organisationUnits = await d2.currentUser.getOrganisationUnits({
-        fields: orgUnitFields,
-    })
+    const organisationUnits = await d2.currentUser.getDataViewOrganisationUnits(
+        {
+            fields: orgUnitFields,
+        }
+    )
     if (organisationUnits.size > 0) {
         return organisationUnits.toArray()
     } else {


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-15651

This changes reports app to display the organisation unit tree based on the user's organisation units for data display/analysis (rather than those for data capture). As this deals with data analysis, I checked in with the analytics team and Scott agreed that there wasn't a reason to be restricting users to the data capture organisation units for any of the report types in the Reports app.