### PR TITLE
fix: expect relative periods to be either undefined or an object

### DIFF
--- a/src/redux/selectors/standardReport/getEditFormInitialValues.js
+++ b/src/redux/selectors/standardReport/getEditFormInitialValues.js
@@ -30,15 +30,15 @@ export const getEditFormInitialValues = createSelector(
                         selectedReport.reportTable.id
                             ? selectedReport.reportTable.id
                             : '',
-                    relativePeriods: Object.keys(
-                        selectedReport.relativePeriods
-                    ).reduce(
-                        (acc, cur) =>
-                            selectedReport.relativePeriods[cur]
-                                ? [...acc, cur]
-                                : acc,
-                        []
-                    ),
+                    relativePeriods: selectedReport.relativePeriods
+                        ? Object.keys(selectedReport.relativePeriods).reduce(
+                              (acc, cur) =>
+                                  selectedReport.relativePeriods[cur]
+                                      ? [...acc, cur]
+                                      : acc,
+                              []
+                          )
+                        : {},
                     reportParams: [
                         selectedReport.reportParams.reportingPeriod
                             ? 'reportingPeriod'


### PR DESCRIPTION
Since the changes[ in this PR:](https://github.com/dhis2/dhis2-core/pull/18691), reports' relative periods come back as undefined if a report does not have a relative period (while before they where returned as empty objects). In this PR i allow for both responses 