### PR TITLE
fix: clean up save with reports app [BETA-155] [DHIS2-19815]

### DIFF
--- a/src/redux/actions/__tests__/standardReport.test.js
+++ b/src/redux/actions/__tests__/standardReport.test.js
@@ -133,7 +133,7 @@ describe('Actions - Standard Reports - Async Thunks', () => {
         })
     })
 
-    describe.only('saving standard reports', () => {
+    describe('saving standard reports', () => {
         afterEach(() => {
             getFilteredStandardReports.mockClear()
         })

--- a/src/redux/actions/__tests__/standardReport.test.js
+++ b/src/redux/actions/__tests__/standardReport.test.js
@@ -168,7 +168,7 @@ describe('Actions - Standard Reports - Async Thunks', () => {
             })
         })
 
-        it.skip('will get relativePeriods and reportParams from form when editing (uses relativePeriod/reportParams definition from report payload)', () => {
+        it('will get relativePeriods and reportParams from form when editing (uses relativePeriod/reportParams definition from report payload)', () => {
             const store = mockStore({
                 standardReport: {
                     selectedReport: {

--- a/src/redux/actions/standardReport.js
+++ b/src/redux/actions/standardReport.js
@@ -15,10 +15,14 @@ import {
     postStandardReport,
     updateStandardReport,
 } from '../../utils/api.js'
-import { formatStandardReportPayloadBySystemVersion } from '../../utils/backwardCompatability.js'
+import {
+    formatStandardReportPayloadBySystemVersion,
+    getDefaultReportParams,
+} from '../../utils/backwardCompatability.js'
 import { fileToText } from '../../utils/fileToText.js'
 import humanReadableErrorMessage from '../../utils/humanReadableErrorMessage.js'
 import { getPeriodStartDate } from '../../utils/periods/periodTypes.js'
+import { flattenedRelativePeriods } from '../../utils/periods/relativePeriods.js'
 import {
     appendOrgUnitsAndReportPeriodToQueryString,
     extractRequiredReportParams,
@@ -394,11 +398,11 @@ export const sendStandardReport = (report, isEdit) => (dispatch, getState) => {
         ...report,
         relativePeriods: processCheckboxValues(
             report.relativePeriods,
-            selectedReport.relativePeriods
+            selectedReport.relativePeriods ?? flattenedRelativePeriods
         ),
         reportParams: processCheckboxValues(
             report.reportParams,
-            selectedReport.reportParams
+            getDefaultReportParams()
         ),
         reportTable: report.reportTable ? { id: report.reportTable } : '',
     }

--- a/src/redux/actions/standardReport.js
+++ b/src/redux/actions/standardReport.js
@@ -402,7 +402,7 @@ export const sendStandardReport = (report, isEdit) => (dispatch, getState) => {
         ),
         reportParams: processCheckboxValues(
             report.reportParams,
-            getDefaultReportParams()
+            selectedReport.reportParams ?? getDefaultReportParams()
         ),
         reportTable: report.reportTable ? { id: report.reportTable } : '',
     }

--- a/src/redux/selectors/standardReport/getEditFormInitialValues.js
+++ b/src/redux/selectors/standardReport/getEditFormInitialValues.js
@@ -40,10 +40,10 @@ export const getEditFormInitialValues = createSelector(
                           )
                         : {},
                     reportParams: [
-                        selectedReport.reportParams.reportingPeriod
+                        selectedReport?.reportParams?.reportingPeriod
                             ? 'reportingPeriod'
                             : '',
-                        selectedReport.reportParams.organisationUnit
+                        selectedReport?.reportParams?.organisationUnit
                             ? 'organisationUnit'
                             : '',
                     ].filter(identity),

--- a/src/utils/backwardCompatability.js
+++ b/src/utils/backwardCompatability.js
@@ -87,12 +87,29 @@ const getReportParamsPropertiesBySystemVersion = (reportParams) => {
     }
 }
 
+export const getDefaultReportParams = () => {
+    if (!isAtLeastVersion34()) {
+        return {
+            paramGrandParentOrganisationUnit: false,
+            paramReportingPeriod: false,
+            paramOrganisationUnit: false,
+            paramParentOrganisationUnit: false,
+        }
+    }
+    return {
+        grandParentOrganisationUnit: false,
+        reportingPeriod: false,
+        organisationUnit: false,
+        parentOrganisationUnit: false,
+    }
+}
+
 export const getStandardReportFieldsBySystemVersion = () => {
     const reportTableField = isAtLeastVersion34()
         ? 'visualization[id,displayName]'
         : 'reportTable[id,displayName]'
 
-    return [':owner', reportTableField]
+    return [':owner', 'relativePeriods', reportTableField]
 }
 
 export const formatStandardReportResponseBySystemVersion = (reportModel) => {


### PR DESCRIPTION
This fixes an issue with saving in the reports app where relativePeriods and reportParams were not being persisted. (See ticket: https://dhis2.atlassian.net/browse/DHIS2-19815)

There are two issues relating to this ticket:

- previously the app was not saving relativePeriods and reportParams on first definition (this is because, it was trying to construct the relativePeriods and reportParams object by looking at the metadata for selected response, but this only existed when you were in edit mode and had got a response from the backend with a definition of relativePeriods and reportParams) (this is not a new problem for v42, we had noticed it and not prioritised fixing it). [There are fixes in this PR to build these objects in new mode]
- as of v42, there is an issue where relativePeriods is not being returned in the `owner` field preset (https://dhis2.atlassian.net/browse/DHIS2-19824), this meant that even in edit mode, there was no comparison point to build relativePeriods. [There is a workaround in this PR to explicitly request relativePeriods]

### testing
I did manual testing. To be honest, I think there's a lot of logical issues with the reports app as is, like what periods are for selection, but I don't want to start enumerating them here, so I just mostly restrained myself to testing what the app already lets you do.
I've added some automatic tests to check that the payload for `relativePeriods`, `reportParams` gets generated appropriately in edit/create mode.